### PR TITLE
Rewriting to use boto3

### DIFF
--- a/nix/ec2-keypair.nix
+++ b/nix/ec2-keypair.nix
@@ -17,6 +17,11 @@ with lib;
       description = "AWS region.";
     };
 
+    profile = mkOption {
+      type = types.str;
+      description = "Name of the profile.";
+    };
+
     accessKeyId = mkOption {
       default = "";
       type = types.str;

--- a/nix/ec2.nix
+++ b/nix/ec2.nix
@@ -175,6 +175,17 @@ in
 
   options = {
 
+    deployment.ec2.profile = mkOption {
+      default = null;
+      example = "dev-Administrator";
+      type = types.str;
+      description = ''
+        The profile name as defined in <filename>~/.aws/config</filename>
+        If left empty it will be left to boto to decide, which means it will
+        check <envvar>AWS_PROFILE</envvar> and use "default".
+      '';
+    };
+
     deployment.ec2.accessKeyId = mkOption {
       default = "";
       example = "AKIABOGUSACCESSKEY";

--- a/nixopsaws/backends/ec2.py
+++ b/nixopsaws/backends/ec2.py
@@ -749,7 +749,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         return instance
 
     def create_instance(self, defn, zone, user_data, ebs_optimized, args):
-        # type: (EC2Definition, str, str, bool, Dict[str, Any]) -> Any
+        # type: (EC2Definition, Optional[str], str, bool, Dict[str, Any]) -> Any
         IamInstanceProfile = {}  # type: Dict[str, str]
         if defn.instance_profile.startswith("arn:"):
             IamInstanceProfile["Arn"] = defn.instance_profile
@@ -1032,9 +1032,6 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                 elif zone != volume.availability_zone:
                     raise Exception("unable to start EC2 instance ‘{0}’ in zone ‘{1}’ because volume ‘{2}’ is in zone ‘{3}’"
                                     .format(self.name, zone, v['disk'], volume.availability_zone))
-
-            if zone is None:
-                raise Exception("unable to start EC2 instance '{0}' because zone was not provided".format(self.name))
 
             # Do we want an EBS-optimized instance?
             prefer_ebs_optimized = False

--- a/nixopsaws/backends/ec2.py
+++ b/nixopsaws/backends/ec2.py
@@ -1576,7 +1576,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         self.wait_for_ssh(check=True)
         self.send_keys()
 
-    def _machine_check(self, res):
+    def _check(self, res):
         # type: (CheckResult) -> None
 
         if not self.vm_id:
@@ -1622,7 +1622,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                 self.private_ipv4 = instance.private_ip_address
                 self.public_ipv4 = instance.public_ip_address
 
-            super(EC2State, self)._machine_check(res)
+            super(EC2State, self)._check(res)
 
         elif instance.state['Name'] == "stopping":
             res.is_up = False

--- a/nixopsaws/backends/ec2.py
+++ b/nixopsaws/backends/ec2.py
@@ -2,35 +2,28 @@
 
 from __future__ import absolute_import, print_function
 
-import os
-import os.path
-import sys
+import datetime
+import math
 import re
 import time
-import math
-import shutil
-import calendar
+from xml.etree.ElementTree import Element
+
 import boto.ec2
 import boto.ec2.blockdevicemapping
 import boto.ec2.networkinterface
+import boto3
 import botocore.exceptions
-
-from nixops.backends import MachineDefinition, MachineState
-from nixops.nix_expr import Function, Call, RawValue
-from ..resources.ebs_volume import EBSVolumeState
-from ..resources.elastic_ip import ElasticIPState
-import nixopsaws.resources.ec2_common
-from nixops.util import device_name_to_boto_expected, device_name_stored_to_real, device_name_user_entered_to_stored
-import nixopsaws.ec2_utils
 import nixops.known_hosts
 import nixops.util
-import nixops.resources.ec2_keypair
-from xml import etree
-import datetime
-import boto3
-from typing import Any, Dict, Optional, List, Iterable
+from nixops.backends import MachineDefinition, MachineState
+from nixops.nix_expr import Call, Function, RawValue
+from nixops.util import device_name_stored_to_real, device_name_to_boto_expected, device_name_user_entered_to_stored
+from typing import Any, Dict, Iterable, List, Optional
+
+import nixopsaws.ec2_utils
+import nixopsaws.resources.ec2_common
+import nixopsaws.resources.ec2_keypair
 from ..ec2_utils import key_value_to_ec2_key_value
-from xml.etree.ElementTree import Element
 
 
 class EC2InstanceDisappeared(Exception):

--- a/nixopsaws/backends/ec2.py
+++ b/nixopsaws/backends/ec2.py
@@ -24,6 +24,7 @@ from nixops.util import device_name_to_boto_expected, device_name_stored_to_real
 import nixopsaws.ec2_utils
 import nixops.known_hosts
 import nixops.util
+import nixops.resources.ec2_keypair
 from xml import etree
 import datetime
 import boto3
@@ -342,7 +343,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         return result[0]
 
     def _get_instance(self, instance_id=None, allow_missing=False, update=False):
-        # type: (Optional[str], bool, bool) -> ...
+        # type: (Optional[str], bool, bool) -> Any
         """Get instance object for this machine, with caching"""
         if not instance_id:
             instance_id = self.vm_id
@@ -371,7 +372,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         elif update:
             self._cached_instance.reload()
 
-        if self._cached_instance.launch_time:
+        if self._cached_instance and self._cached_instance.launch_time:
             self.start_time = self._cached_instance.launch_time
 
         return self._cached_instance
@@ -651,6 +652,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             raise Exception("operation timed out")
         else:
             self.log_end('')
+            return True
 
     def _assign_elastic_ip(self, elastic_ipv4, check):
         instance = self._get_instance()
@@ -731,29 +733,30 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         return group_ids
 
     def _wait_for_spot_request_fulfillment(self, request_id):
-        # type: (str) -> ...
+        # type: (str) -> Any
 
         self.log_start("waiting for spot instance request ‘{0}’ to be fulfilled... ".format(self.spot_instance_request_id))
         while True:
             request = self._get_spot_instance_request_by_id(self.spot_instance_request_id)
-            self.log_continue("[{0}] ".format(request.status.code))
-            if request.status.code == "fulfilled":
+            assert request
+            self.log_continue("[{0}] ".format(request['Status']['Code']))
+            if request['Status']['Code'] == "fulfilled":
                 break
 
-            if request.status.code in {"schedule-expired", "canceled-before-fulfillment", "bad-parameters", "system-error"}:
+            if request['Status']['Code'] in {"schedule-expired", "canceled-before-fulfillment", "bad-parameters", "system-error"}:
                 self.spot_instance_request_id = None
                 self.log_end("")
-                raise Exception("spot instance request failed with result ‘{0}’".format(request.status.code))
+                raise Exception("spot instance request failed with result ‘{0}’".format(request['Status']['Code']))
 
             time.sleep(3)
         self.log_end("")
 
-        instance = self._retry(lambda: self._get_instance(instance_id=request.instance_id))
+        instance = self._retry(lambda: self._get_instance(instance_id=request['InstanceId']))
 
         return instance
 
     def create_instance(self, defn, zone, user_data, ebs_optimized, args):
-        # type: (EC2Definition, str, str, bool, Dict[str, Any]) -> ...
+        # type: (EC2Definition, str, str, bool, Dict[str, Any]) -> Any
         IamInstanceProfile = {}  # type: Dict[str, str]
         if defn.instance_profile.startswith("arn:"):
             IamInstanceProfile["Arn"] = defn.instance_profile
@@ -910,7 +913,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
         # Figure out the access key.
         self.access_key_id = defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
-        
+
         self.private_key_file = defn.private_key or None
 
         if self.region is None:
@@ -982,7 +985,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             # Check if we need to resize the root disk
             resize_root = defn.root_disk_size != 0 and ami.root_device_type == 'ebs'
 
-            args = dict()
+            args = dict()  # type: Dict[str, Any]
 
             # Set the initial block device mapping to the ephemeral
             # devices defined in the spec.  These cannot be changed
@@ -1023,9 +1026,12 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             # we create the instance in the right placement zone.
             zone = defn.zone or None
             for device_stored, v in defn.block_device_mapping.iteritems():
-                if not v['disk'].startswith("vol-"): continue
+                if not v['disk'].startswith("vol-"):
+                    continue
                 # Make note of the placement zone of the volume.
                 volume = nixopsaws.ec2_utils.get_volume_by_id(self.session(), v['disk'])
+                assert volume
+
                 if not zone:
                     self.log("starting EC2 instance in zone ‘{0}’ due to volume ‘{1}’".format(
                             volume.availability_zone, v['disk']))
@@ -1033,6 +1039,9 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                 elif zone != volume.availability_zone:
                     raise Exception("unable to start EC2 instance ‘{0}’ in zone ‘{1}’ because volume ‘{2}’ is in zone ‘{3}’"
                                     .format(self.name, zone, v['disk'], volume.availability_zone))
+
+            if zone is None:
+                raise Exception("unable to start EC2 instance '{0}' because zone was not provided".format(self.name))
 
             # Do we want an EBS-optimized instance?
             prefer_ebs_optimized = False
@@ -1300,7 +1309,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                                           or v['disk'].startswith("vol-")))
                     or 'partOfImage' in v):
                 continue
-            volume_tags = {}
+            volume_tags = {}  # type: Dict[str, str]
             volume_tags.update(common_tags)
             volume_tags.update(defn.tags)
             volume_tags['Name'] = "{0} [{1} - {2}]".format(self.depl.description, self.name, device_real)

--- a/nixopsaws/backends/ec2.py
+++ b/nixopsaws/backends/ec2.py
@@ -15,6 +15,7 @@ import boto3
 import botocore.exceptions
 import nixops.known_hosts
 import nixops.util
+from nixops.backends import CheckResult
 from nixops.backends import MachineDefinition, MachineState
 from nixops.nix_expr import Call, Function, RawValue
 from nixops.util import device_name_stored_to_real, device_name_to_boto_expected, device_name_user_entered_to_stored
@@ -1575,69 +1576,71 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         self.wait_for_ssh(check=True)
         self.send_keys()
 
-    def _check(self, res):
+    def _machine_check(self, res):
+        # type: (CheckResult) -> None
+
         if not self.vm_id:
             res.exists = False
             return
 
-        self.connect()
         instance = self._get_instance(allow_missing=True)
         old_state = self.state
         #self.log("instance state is ‘{0}’".format(instance.state if instance else "gone"))
 
-        if instance is None or instance.state in {"shutting-down", "terminated"}:
+        if instance is None or instance.state['Name'] in {"shutting-down", "terminated"}:
             self.state = self.MISSING
             self.vm_id = None
             return
 
         res.exists = True
-        if instance.state == "pending":
+        if instance.state['Name'] == "pending":
             res.is_up = False
             self.state = self.STARTING
 
-        elif instance.state == "running":
+        elif instance.state['Name'] == "running":
             res.is_up = True
 
             res.disks_ok = True
+            mappings = {mapping['DeviceName']: {"Ebs": mapping["Ebs"]} for mapping in instance.block_device_mappings}
             for device_stored, v in self.block_device_mapping.items():
                 device_real = device_name_stored_to_real(device_stored)
-                device_that_boto_expects = device_name_to_boto_expected(device_real) # boto expects only sd names
+                device_that_boto_expects = device_name_to_boto_expected(device_real)  # boto expects only sd names
 
-                if device_that_boto_expects not in instance.block_device_mapping.keys() and v.get('volumeId', None):
+                if device_that_boto_expects not in mappings.keys() and v.get('volumeId', None):
                     res.disks_ok = False
                     res.messages.append("volume ‘{0}’ not attached to ‘{1}’".format(v['volumeId'], device_real))
-                    volume = nixopsaws.ec2_utils.get_volume_by_id(self.connect(), v['volumeId'], allow_missing=True)
+                    volume = nixopsaws.ec2_utils.get_volume_by_id(self.session(), v['volumeId'], allow_missing=True)
                     if not volume:
                         res.messages.append("volume ‘{0}’ no longer exists".format(v['volumeId']))
 
-                if device_that_boto_expects in instance.block_device_mapping.keys() and instance.block_device_mapping[device_that_boto_expects].status != 'attached' :
+                if device_that_boto_expects in mappings.keys() and mappings[device_that_boto_expects]['Ebs']['Status'] != 'attached':
                     res.disks_ok = False
-                    res.messages.append("volume ‘{0}’ on device ‘{1}’ has unexpected state: ‘{2}’".format(v['volumeId'], device_real, instance.block_device_mapping[device_stored].status))
+                    res.messages.append("volume ‘{0}’ on device ‘{1}’ has unexpected state: ‘{2}’".format(v['volumeId'], device_real, mappings[device_stored]['Ebs']['Status']))
 
-
-            if self.private_ipv4 != instance.private_ip_address or self.public_ipv4 != instance.ip_address:
+            if self.private_ipv4 != instance.private_ip_address or self.public_ipv4 != instance.public_ip_address:
                 self.warn("IP address has changed, you may need to run ‘nixops deploy’")
                 self.private_ipv4 = instance.private_ip_address
-                self.public_ipv4 = instance.ip_address
+                self.public_ipv4 = instance.public_ip_address
 
-            MachineState._check(self, res)
+            super(EC2State, self)._machine_check(res)
 
-        elif instance.state == "stopping":
+        elif instance.state['Name'] == "stopping":
             res.is_up = False
             self.state = self.STOPPING
 
-        elif instance.state == "stopped":
+        elif instance.state['Name'] == "stopped":
             res.is_up = False
             self.state = self.STOPPED
 
         # check for scheduled events
-        instance_status = self._conn.get_all_instance_status(instance_ids=[instance.id])
+        ec2 = self.session().client('ec2')
+        instance_status = ec2.describe_instance_status(InstanceIds=[instance.id], IncludeAllInstances=True)['InstanceStatuses']
         for ist in instance_status:
-            if ist.events:
-                for e in ist.events:
-                    res.messages.append("Event ‘{0}’:".format(e.code))
-                    res.messages.append("  * {0}".format(e.description))
-                    res.messages.append("  * {0} - {1}".format(e.not_before, e.not_after))
+            if 'Events' in ist:
+                for e in ist['Events']:
+                    res.messages.append("Event ‘{0}’:".format(e['Code']))
+                    res.messages.append("  * {0}".format(e['Description']))
+                    res.messages.append("  * {0} - {1}".format(e['NotBefore'], e['NotAfters']))
 
     def reboot(self, hard=False):
         # type: (bool) -> None

--- a/nixopsaws/backends/ec2.py
+++ b/nixopsaws/backends/ec2.py
@@ -1639,20 +1639,22 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                     res.messages.append("  * {0}".format(e.description))
                     res.messages.append("  * {0} - {1}".format(e.not_before, e.not_after))
 
-
     def reboot(self, hard=False):
+        # type: (bool) -> None
+
         self.log("rebooting EC2 machine...")
         instance = self._get_instance()
         instance.reboot()
         self.state = self.STARTING
 
-
     def get_console_output(self):
+        # type: () -> str
+
         if not self.vm_id:
             raise Exception("cannot get console output of non-existant machine ‘{0}’".format(self.name))
-        self.connect()
-        return self._conn.get_console_output(self.vm_id).output or "(not available)"
 
+        ec2 = self.session().client('ec2')
+        return ec2.get_console_output(InstanceId=self.vm_id)['Output'] or "(not available)"
 
     def next_charge_time(self):
         if not self.start_time:

--- a/nixopsaws/backends/ec2.py
+++ b/nixopsaws/backends/ec2.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, print_function
+
 import os
 import os.path
 import sys
@@ -10,18 +13,24 @@ import calendar
 import boto.ec2
 import boto.ec2.blockdevicemapping
 import boto.ec2.networkinterface
+import botocore.exceptions
+
 from nixops.backends import MachineDefinition, MachineState
 from nixops.nix_expr import Function, Call, RawValue
-from nixopsaws.resources.ebs_volume import EBSVolumeState
-from nixopsaws.resources.elastic_ip import ElasticIPState
+from ..resources.ebs_volume import EBSVolumeState
+from ..resources.elastic_ip import ElasticIPState
 import nixopsaws.resources.ec2_common
-import nixopsaws.resources
 from nixops.util import device_name_to_boto_expected, device_name_stored_to_real, device_name_user_entered_to_stored
 import nixopsaws.ec2_utils
 import nixops.known_hosts
+import nixops.util
 from xml import etree
 import datetime
 import boto3
+from typing import Any, Dict, Optional, List, Iterable
+from ..ec2_utils import key_value_to_ec2_key_value
+from xml.etree.ElementTree import Element
+
 
 class EC2InstanceDisappeared(Exception):
     pass
@@ -32,16 +41,20 @@ class EC2InstanceDisappeared(Exception):
 # device_real - device name attached to machine: xvd or nvme, sd can't be attached
 # device_that_boto_expects - only sd device names can be passed to boto, but amazon will attach them as xvd or nvme based on machine type
 
+
 class EC2Definition(MachineDefinition):
     """Definition of an EC2 machine."""
 
     @classmethod
     def get_type(cls):
+        # type: () -> str
         return "ec2"
 
     def __init__(self, xml, config):
-        MachineDefinition.__init__(self, xml, config)
+        # type: (Element, Dict[str, Any]) -> None
+        super(EC2Definition, self).__init__(xml, config)
 
+        self.profile = config["ec2"]["profile"]
         self.access_key_id = config["ec2"]["accessKeyId"]
         self.region = config["ec2"]["region"]
         self.zone = config["ec2"]["zone"]
@@ -80,9 +93,11 @@ class EC2Definition(MachineDefinition):
         self.route53_private = config["route53"]["private"]
 
     def show_type(self):
+        # type: () -> str
         return "{0} [{1}]".format(self.get_type(), self.region or self.zone or "???")
 
     def host_key_type(self):
+        # type: () -> str
         return "ed25519" if nixops.util.parse_nixos_version(self.config["nixosRelease"]) >= ["15", "09"] else "dsa"
 
 
@@ -91,6 +106,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
     @classmethod
     def get_type(cls):
+        # type: () -> str
         return "ec2"
 
     state = nixops.util.attr_property("state", MachineState.MISSING, int)  # override
@@ -104,6 +120,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
     source_dest_check = nixops.util.attr_property("ec2.sourceDestCheck", True, type=bool)
     associate_public_ip_address = nixops.util.attr_property("ec2.associatePublicIpAddress", False, type=bool)
     elastic_ipv4 = nixops.util.attr_property("ec2.elasticIpv4", None)
+    profile = nixops.util.attr_property("ec2.profile", None)
     access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
     region = nixops.util.attr_property("ec2.region", None)
     zone = nixops.util.attr_property("ec2.zone", None)
@@ -132,15 +149,16 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
     virtualization_type = nixops.util.attr_property("ec2.virtualizationType", None)
 
     def __init__(self, depl, name, id):
-        MachineState.__init__(self, depl, name, id)
-        self._conn = None
-        self._conn_vpc = None
+        # type: (EC2Definition, str, str) -> None
+        super(EC2State, self).__init__(depl, name, id)
+
+        self._session = None  # type: boto3.session.Session
         self._conn_route53 = None
-        self._conn_boto3 = None
         self._cached_instance = None
 
-
     def _reset_state(self):
+        # type: () -> None
+
         """Discard all state pertaining to an instance."""
         with self.depl._db:
             self.state = MachineState.MISSING
@@ -177,32 +195,40 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             self.spot_instance_price = None
 
     def get_ssh_name(self):
-        retVal = None
+        # type: () -> str
+
         if self.use_private_ip_address:
             if not self.private_ipv4:
                 raise Exception("EC2 machine '{0}' does not have a private IPv4 address (yet)".format(self.name))
-            retVal = self.private_ipv4
+            return self.private_ipv4
         else:
             if not self.public_ipv4:
                 raise Exception("EC2 machine ‘{0}’ does not have a public IPv4 address (yet)".format(self.name))
-            retVal = self.public_ipv4
-        return retVal
-
+            return self.public_ipv4
 
     def get_ssh_private_key_file(self):
-        if self.private_key_file: return self.private_key_file
-        if self._ssh_private_key_file: return self._ssh_private_key_file
+        # type: () -> Optional[str]
+
+        if self.private_key_file:
+            return self.private_key_file
+
+        if self._ssh_private_key_file:
+            return self._ssh_private_key_file
+
         for r in self.depl.active_resources.itervalues():
             if isinstance(r, nixopsaws.resources.ec2_keypair.EC2KeyPairState) and \
                     r.state == nixopsaws.resources.ec2_keypair.EC2KeyPairState.UP and \
                     r.keypair_name == self.key_pair:
                 return self.write_ssh_private_key(r.private_key)
+
         return None
 
-
     def get_ssh_flags(self, *args, **kwargs):
+        # type: (*Any, **Any) -> List[str]
+
         file = self.get_ssh_private_key_file()
         super_flags = super(EC2State, self).get_ssh_flags(*args, **kwargs)
+
         return super_flags + (["-i", file] if file else [])
 
     def get_physical_spec(self):
@@ -275,22 +301,16 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             return m.private_ipv4
         return MachineState.address_to(self, m)
 
+    def session(self):
+        # type: () -> boto3.Session
+        if not self._session:
+            self._session = nixopsaws.ec2_utils.session(**{
+                "region_name": self.region,
+                "profile_name": self.profile,
+                "aws_access_key_id": self.access_key_id
+            })
 
-    def connect(self):
-        if self._conn: return self._conn
-        self._conn = nixopsaws.ec2_utils.connect(self.region, self.access_key_id)
-        return self._conn
-
-    def connect_boto3(self):
-        if self._conn_boto3: return self._conn_boto3
-        self._conn_boto3 = nixopsaws.ec2_utils.connect_ec2_boto3(self.region, self.access_key_id)
-        return self._conn_boto3
-
-    def connect_vpc(self):
-        if self._conn_vpc:
-            return self._conn_vpc
-        self._conn_vpc = nixopsaws.ec2_utils.connect_vpc(self.region, self.access_key_id)
-        return self._conn_vpc
+        return self._session
 
     def connect_route53(self):
         if self._conn_route53:
@@ -301,49 +321,58 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
         self._conn_route53 = boto.connect_route53(access_key_id, secret_access_key)
 
-
     def _get_spot_instance_request_by_id(self, request_id, allow_missing=False):
+        # type: (str, bool) -> Optional[Dict[str, Any]]
         """Get spot instance request object by id."""
-        self.connect()
+        ec2 = self.session().client('ec2')
         try:
-            result = self._conn.get_all_spot_instance_requests([request_id])
-        except boto.exception.EC2ResponseError as e:
-            if allow_missing and e.error_code == "InvalidSpotInstanceRequestID.NotFound":
+            result = ec2.describe_spot_instance_requests(SpotInstanceRequestsIds=[request_id])['SpotInstanceRequests']
+        except botocore.exceptions.ClientError as e:
+            if allow_missing and e.response['Error']['Code'] == "InvalidSpotInstanceRequestID.NotFound":
                 result = []
             else:
                 raise
+
         if len(result) == 0:
             if allow_missing:
                 return None
+
             raise EC2InstanceDisappeared("Spot instance request ‘{0}’ disappeared!".format(request_id))
+
         return result[0]
 
-
     def _get_instance(self, instance_id=None, allow_missing=False, update=False):
+        # type: (Optional[str], bool, bool) -> ...
         """Get instance object for this machine, with caching"""
-        if not instance_id: instance_id = self.vm_id
+        if not instance_id:
+            instance_id = self.vm_id
         assert instance_id
 
         if not self._cached_instance:
-            self.connect()
+            ec2 = self.session().resource('ec2')
+            instance = ec2.Instance(instance_id)
+
             try:
-                instances = self._conn.get_only_instances([instance_id])
-            except boto.exception.EC2ResponseError as e:
-                if allow_missing and e.error_code == "InvalidInstanceID.NotFound":
-                    instances = []
+                instance.load()
+            except botocore.exceptions.ClientError as e:
+                if allow_missing and e.response['Error']['Code'] == "InvalidInstanceID.NotFound":
+                    instance = None
                 else:
                     raise
-            if len(instances) == 0:
+
+            if not instance:
                 if allow_missing:
                     return None
+
                 raise EC2InstanceDisappeared("EC2 instance ‘{0}’ disappeared!".format(instance_id))
-            self._cached_instance = instances[0]
+
+            self._cached_instance = instance
 
         elif update:
-            self._cached_instance.update()
+            self._cached_instance.reload()
 
         if self._cached_instance.launch_time:
-            self.start_time = calendar.timegm(time.strptime(self._cached_instance.launch_time, "%Y-%m-%dT%H:%M:%S.000Z"))
+            self.start_time = self._cached_instance.launch_time
 
         return self._cached_instance
 
@@ -356,14 +385,12 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             raise Exception("unable to find snapshot ‘{0}’".format(snapshot_id))
         return snapshots[0]
 
-
-
     def _wait_for_ip(self):
         self.log_start("waiting for IP address... ".format(self.name))
 
         def _instance_ip_ready(ins):
             ready = True
-            if self.associate_public_ip_address and not ins.ip_address:
+            if self.associate_public_ip_address and not ins.public_ip_address:
                 ready = False
             if self.use_private_ip_address and not ins.private_ip_address:
                 ready = False
@@ -371,21 +398,21 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
         while True:
             instance = self._get_instance(update=True)
-            self.log_continue("[{0}] ".format(instance.state))
-            if instance.state not in {"pending", "running", "scheduling", "launching", "stopped"}:
-                raise Exception("EC2 instance ‘{0}’ failed to start (state is ‘{1}’)".format(self.vm_id, instance.state))
-            if instance.state != "running":
+            self.log_continue("[{0}] ".format(instance.state['Name']))
+            if instance.state['Name'] not in {"pending", "running", "scheduling", "launching", "stopped"}:
+                raise Exception("EC2 instance ‘{0}’ failed to start (state is ‘{1}’)".format(self.vm_id, instance.state['Name']))
+            if instance.state['Name'] != "running":
                 time.sleep(3)
                 continue
             if _instance_ip_ready(instance):
                 break
             time.sleep(3)
 
-        self.log_end("{0} / {1}".format(instance.ip_address, instance.private_ip_address))
+        self.log_end("{0} / {1}".format(instance.public_ip_address, instance.private_ip_address))
 
         with self.depl._db:
             self.private_ipv4 = instance.private_ip_address
-            self.public_ipv4 = instance.ip_address
+            self.public_ipv4 = instance.public_ip_address
             self.public_dns_name = instance.public_dns_name
             self.ssh_pinged = False
 
@@ -398,12 +425,13 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             return self.public_ipv4
 
     def _booted_from_ebs(self):
+        # type: () -> bool
         return self.root_device_type == "ebs"
 
 
     def update_block_device_mapping(self, k, v):
         x = self.block_device_mapping
-        if v == None:
+        if v is None:
             x.pop(k, None)
         else:
             x[k] = v
@@ -559,49 +587,52 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                 isinstance(r, nixopsaws.resources.elastic_file_system.ElasticFileSystemState) or
                 isinstance(r, nixopsaws.resources.elastic_file_system_mount_target.ElasticFileSystemMountTargetState)}
 
-
     def attach_volume(self, device_stored, volume_id):
+        # type: (str, str) -> bool
+
         device_real = device_name_stored_to_real(device_stored)
 
-        volume = nixopsaws.ec2_utils.get_volume_by_id(self.connect(), volume_id)
+        volume = nixopsaws.ec2_utils.get_volume_by_id(self.session(), volume_id)
         if not volume:
             raise Exception("volume {0} doesn't exist, run check to update the state of the volume".format(volume_id))
-        if volume.status == "in-use" and \
-            self.vm_id != volume.attach_data.instance_id and \
-            self.depl.logger.confirm("volume ‘{0}’ is in use by instance ‘{1}’, "
-                                     "are you sure you want to attach this volume?".format(volume_id, volume.attach_data.instance_id)):
 
-            self.log_start("detaching volume ‘{0}’ from instance ‘{1}’... ".format(volume_id, volume.attach_data.instance_id))
-            volume.detach()
+        if volume.state == "in-use" and \
+                self.vm_id != volume.attachments[0]['InstanceId'] and \
+                self.depl.logger.confirm("volume ‘{0}’ is in use by instance ‘{1}’, "
+                                         "are you sure you want to attach this volume?".format(volume_id, volume.attachments[0]['InstanceId'])):
+
+            self.log_start("detaching volume ‘{0}’ from instance ‘{1}’... ".format(volume_id, volume.attachments[0]['InstanceId']))
+            volume.detach_from_instance()
 
             def check_available():
-                res = volume.update()
-                self.log_continue("[{0}] ".format(res))
-                return res == 'available'
+                volume.reload()
+                self.log_continue("[{0}] ".format(volume.state))
+                return volume.state == 'available'
 
             nixops.util.check_wait(check_available)
             self.log_end('')
 
-            if volume.update() != "available":
-                self.log("force detaching volume ‘{0}’ from instance ‘{1}’...".format(volume_id, volume.attach_data.instance_id))
-                volume.detach(True)
+            volume.reload()
+            if volume.state != "available":
+                self.log("force detaching volume ‘{0}’ from instance ‘{1}’...".format(volume_id, volume.attachments[0]['InstanceId']))
+                volume.detach_from_instance(Force=True)
                 nixops.util.check_wait(check_available)
 
         self.log_start("attaching volume ‘{0}’ as ‘{1}’... ".format(volume_id, device_real))
 
-        if self.vm_id != volume.attach_data.instance_id:
+        if self.vm_id != volume.volume.attachments[0]['InstanceId']:
             # Attach it.
             device_that_boto_expects = device_name_to_boto_expected(device_stored)
-            self._conn.attach_volume(volume_id, self.vm_id, device_that_boto_expects)
+            volume.attach_to_instance(InstanceId=self.vm_id, Device=device_that_boto_expects)
 
         def check_attached():
-            volume.update()
-            res = volume.attach_data.status
+            volume.reload()
+            res = volume.state
             self.log_continue("[{0}] ".format(res or "not-attached"))
             return res == 'attached'
 
         # If volume is not in attached state, wait for it before going on.
-        if volume.attach_data.status != "attached":
+        if volume.state != "attached":
             nixops.util.check_wait(check_attached)
 
         # Wait until the device is visible in the instance.
@@ -625,38 +656,40 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         instance = self._get_instance()
 
         # Assign or release an elastic IP address, if given.
-        if (self.elastic_ipv4 or "") != elastic_ipv4 or (instance.ip_address != elastic_ipv4) or check:
+        if (self.elastic_ipv4 or "") != elastic_ipv4 or (instance.public_ip_address != elastic_ipv4) or check:
             if elastic_ipv4 != "":
                 # wait until machine is in running state
                 self.log_start("waiting for machine to be in running state... ".format(self.name))
                 while True:
-                    self.log_continue("[{0}] ".format(instance.state))
-                    if instance.state == "running":
+                    self.log_continue("[{0}] ".format(instance.state['Name']))
+                    if instance.state['Name'] == "running":
                         break
-                    if instance.state not in {"running", "pending"}:
+                    if instance.state['Name'] not in {"running", "pending"}:
                         raise Exception(
                             "EC2 instance ‘{0}’ failed to reach running state (state is ‘{1}’)"
-                            .format(self.vm_id, instance.state))
+                            .format(self.vm_id, instance.state['Name']))
                     time.sleep(3)
                     instance = self._get_instance(update=True)
                 self.log_end("")
 
-                addresses = self._conn.get_all_addresses(addresses=[elastic_ipv4])
-                if addresses[0].instance_id != "" \
-                    and addresses[0].instance_id is not None \
-                    and addresses[0].instance_id != self.vm_id \
+                ec2 = self.session().client('ec2')
+                addresses = ec2.describe_addresses(PublicIps=[elastic_ipv4])['Addresses']
+                if addresses[0]['InstanceId'] != "" \
+                    and addresses[0]['InstanceId'] is not None \
+                    and addresses[0]['InstanceId'] != self.vm_id \
                     and not self.depl.logger.confirm(
                         "are you sure you want to associate IP address ‘{0}’, which is currently in use by instance ‘{1}’?".format(
-                            elastic_ipv4, addresses[0].instance_id)):
+                            elastic_ipv4, addresses[0]['InstanceId'])):
                     raise Exception("elastic IP ‘{0}’ already in use...".format(elastic_ipv4))
                 else:
                     self.log("associating IP address ‘{0}’...".format(elastic_ipv4))
-                    addresses[0].associate(self.vm_id)
+                    ec2.associate_address(AllocationId=addresses[0]['AllocationId'], InstanceId=self.vm_id)
+
                     self.log_start("waiting for address to be associated with this machine... ")
                     instance = self._get_instance(update=True)
                     while True:
-                        self.log_continue("[{0}] ".format(instance.ip_address))
-                        if instance.ip_address == elastic_ipv4:
+                        self.log_continue("[{0}] ".format(instance.public_ip_address))
+                        if instance.public_ip_address == elastic_ipv4:
                             break
                         time.sleep(3)
                         instance = self._get_instance(update=True)
@@ -669,11 +702,13 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                     self.public_ipv4 = elastic_ipv4
                     self.ssh_pinged = False
 
-            elif self.elastic_ipv4 != None:
-                addresses = self._conn.get_all_addresses(addresses=[self.elastic_ipv4])
-                if len(addresses) == 1 and addresses[0].instance_id == self.vm_id:
+            elif self.elastic_ipv4 is not None:
+                ec2 = self.session().client('ec2')
+                addresses = ec2.describe_addresses(PublicIps=[self.elastic_ipv4])['Addresses']
+
+                if len(addresses) == 1 and addresses[0]['InstanceId'] == self.vm_id:
                     self.log("disassociating IP address ‘{0}’...".format(self.elastic_ipv4))
-                    self._conn.disassociate_address(public_ip=self.elastic_ipv4)
+                    ec2.disassociate_address(PublicIp=self.elastic_ipv4)
                 else:
                     self.log("address ‘{0}’ was not associated with instance ‘{1}’".format(self.elastic_ipv4, self.vm_id))
 
@@ -683,25 +718,33 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                     self.ssh_pinged = False
 
     def security_groups_to_ids(self, subnetId, groups):
-        sg_names = filter(lambda g: not g.startswith('sg-'), groups)
-        if sg_names != [ ] and subnetId != "":
-            self.connect_vpc()
-            vpc_id = self._conn_vpc.get_all_subnets([subnetId])[0].vpc_id
-            groups = map(lambda g: nixopsaws.ec2_utils.name_to_security_group(self._conn, g, vpc_id), groups)
+        # type: (str, Iterable[str]) -> List[str]
 
-        return groups
+        group_ids = [g for g in groups if g.startswith('sg-')]
+        sg_names = [g for g in groups if not g.startswith('sg-')]
+        if sg_names and subnetId:
+            ec2 = self.session().resource('ec2')
+            subnet = ec2.Subnet(subnetId)
+            vpc_id = subnet.vpc_id
+            group_ids += [nixopsaws.ec2_utils.name_to_security_group(self.session(), g, vpc_id) for g in groups]
+
+        return group_ids
 
     def _wait_for_spot_request_fulfillment(self, request_id):
+        # type: (str) -> ...
 
         self.log_start("waiting for spot instance request ‘{0}’ to be fulfilled... ".format(self.spot_instance_request_id))
         while True:
             request = self._get_spot_instance_request_by_id(self.spot_instance_request_id)
             self.log_continue("[{0}] ".format(request.status.code))
-            if request.status.code == "fulfilled": break
+            if request.status.code == "fulfilled":
+                break
+
             if request.status.code in {"schedule-expired", "canceled-before-fulfillment", "bad-parameters", "system-error"}:
                 self.spot_instance_request_id = None
                 self.log_end("")
                 raise Exception("spot instance request failed with result ‘{0}’".format(request.status.code))
+
             time.sleep(3)
         self.log_end("")
 
@@ -709,16 +752,16 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
         return instance
 
-
     def create_instance(self, defn, zone, user_data, ebs_optimized, args):
-        IamInstanceProfile = {}
-        if defn.instance_profile.startswith("arn:") :
+        # type: (EC2Definition, str, str, bool, Dict[str, Any]) -> ...
+        IamInstanceProfile = {}  # type: Dict[str, str]
+        if defn.instance_profile.startswith("arn:"):
             IamInstanceProfile["Arn"] = defn.instance_profile
         else:
             IamInstanceProfile["Name"] = defn.instance_profile
 
-        if defn.subnet_id != "":
-            if defn.security_groups != [] and defn.security_groups != ["default"]:
+        if defn.subnet_id:
+            if defn.security_groups and defn.security_groups != ["default"]:
                 raise Exception("‘deployment.ec2.securityGroups’ is incompatible with ‘deployment.ec2.subnetId’")
 
             args['NetworkInterfaces'] = [dict(
@@ -740,7 +783,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                 )
             )
             if defn.spot_instance_timeout:
-                args["InstanceMarketOptions"]["SpotOptions"]["ValidUntil"]=(datetime.datetime.utcnow() +
+                args["InstanceMarketOptions"]["SpotOptions"]["ValidUntil"] = (datetime.datetime.utcnow() +
                     datetime.timedelta(0, defn.spot_instance_timeout)).isoformat()
 
         placement = dict(
@@ -756,7 +799,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         args['Placement'] = placement
         args['UserData'] = user_data
         args['EbsOptimized'] = ebs_optimized
-        args['MaxCount'] = 1 # We always want to deploy one instance.
+        args['MaxCount'] = 1  # We always want to deploy one instance.
         args['MinCount'] = 1
 
         # Use a client token to ensure that instance creation is
@@ -765,13 +808,15 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         # next run.
         if not self.client_token:
             with self.depl._db:
-                self.client_token = nixops.util.generate_random_string(length=48) # = 64 ASCII chars
+                self.client_token = nixops.util.generate_random_string(length=48)  # = 64 ASCII chars
                 self.state = self.STARTING
 
         args["ClientToken"] = self.client_token
 
+        ec2 = self.session().client('ec2')
+
         reservation = self._retry(
-            lambda: self._conn_boto3.run_instances(**args)
+            lambda: ec2.run_instances(**args)
         )
 
         if not defn.spot_instance_price:
@@ -785,7 +830,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         tags = {'Name': "{0} [{1}]".format(self.depl.description, self.name)}
         tags.update(defn.tags)
         tags.update(self.get_common_tags())
-        self._retry(lambda: self._conn.create_tags([self.spot_instance_request_id], tags))
+        self._retry(lambda: ec2.create_tags(Resources=[self.spot_instance_request_id], Tags=key_value_to_ec2_key_value(tags)))
 
         return self._wait_for_spot_request_fulfillment(self.spot_instance_request_id)
 
@@ -850,8 +895,8 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
                 self.update_block_device_mapping(device_stored, None)
 
-
     def create(self, defn, check, allow_reboot, allow_recreate):
+        # type: (EC2Definition, bool, bool, bool) -> None
         assert isinstance(defn, EC2Definition)
 
         if self.state != self.UP:
@@ -865,9 +910,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
         # Figure out the access key.
         self.access_key_id = defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
-        if not self.access_key_id:
-            raise Exception("please set ‘deployment.ec2.accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID")
-
+        
         self.private_key_file = defn.private_key or None
 
         if self.region is None:
@@ -875,11 +918,11 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         elif self.region != defn.region:
             self.warn("cannot change region of a running instance (from ‘{}‘ to ‘{}‘)".format(self.region, defn.region))
 
+        if self.profile is None:
+            self.profile = defn.profile
+
         if self.key_pair and self.key_pair != defn.key_pair:
             raise Exception("cannot change key pair of an existing instance (from ‘{}‘ to ‘{}‘)".format(self.key_pair, defn.key_pair))
-
-        self.connect()
-        self.connect_boto3()
 
         # Stop the instance (if allowed) to change instance attributes
         # such as the type.
@@ -892,24 +935,24 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         if self.vm_id and check:
             instance = self._get_instance(allow_missing=True)
 
-            if instance is None or instance.state in {"shutting-down", "terminated"}:
+            if instance is None or instance.state['Name'] in {"shutting-down", "terminated"}:
                 if not allow_recreate:
                     raise Exception("EC2 instance ‘{0}’ went away; use ‘--allow-recreate’ to create a new one".format(self.name))
-                self.log("EC2 instance went away (state ‘{0}’), will recreate".format(instance.state if instance else "gone"))
+                self.log("EC2 instance went away (state ‘{0}’), will recreate".format(instance.state['Name'] if instance else "gone"))
                 self._reset_state()
                 self.region = defn.region
-            elif instance.state == "stopped":
+            elif instance.state['Name'] == "stopped":
                 self.log("EC2 instance was stopped, restarting...")
 
                 # Modify the instance type, if desired.
                 if self.instance_type != defn.instance_type:
                     self.log("changing instance type from ‘{0}’ to ‘{1}’...".format(self.instance_type, defn.instance_type))
-                    instance.modify_attribute("instanceType", defn.instance_type)
+                    instance.modify_attribute(InstanceType={'Value': defn.instance_type})
                     self.instance_type = defn.instance_type
 
                 if self.ebs_optimized != defn.ebs_optimized:
                     self.log("changing ebs optimized flag from ‘{0}’ to ‘{1}’...".format(self.ebs_optimized, defn.ebs_optimized))
-                    instance.modify_attribute("ebsOptimized", defn.ebs_optimized)
+                    instance.modify_attribute(EbsOptimized={'Value': defn.ebs_optimized})
                     self.ebs_optimized = defn.ebs_optimized
 
                 # When we restart, we'll probably get a new IP.  So forget the current one.
@@ -931,17 +974,13 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             if not self.client_token and not self.spot_instance_request_id:
                 self._reset_state()
                 self.region = defn.region
-                self.connect()
 
-            # Figure out whether this AMI is EBS-backed.
-            amis = self._conn_boto3.describe_images(ImageIds=[defn.ami])
-            if len(amis) == 0:
-                raise Exception("AMI ‘{0}’ does not exist in region ‘{1}’".format(defn.ami, self.region))
-            ami = self._conn_boto3.describe_images(ImageIds=[defn.ami])['Images'][0]
-            self.root_device_type = ami['RootDeviceType']
+            ec2 = self.session().resource('ec2')
+            ami = ec2.Image(defn.ami)
+            self.root_device_type = ami.root_device_type
 
             # Check if we need to resize the root disk
-            resize_root = defn.root_disk_size != 0 and ami['RootDeviceType'] == 'ebs'
+            resize_root = defn.root_disk_size != 0 and ami.root_device_type == 'ebs'
 
             args = dict()
 
@@ -969,14 +1008,14 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                     args['BlockDeviceMappings'].append(ephemeral_mapping)
                     self.update_block_device_mapping(device_stored, v)
 
-            root_device = ami['RootDeviceName']
+            root_device = ami.root_device_name
             if resize_root:
                 root_mapping = dict(
                     DeviceName=root_device,
                     Ebs=dict(
                         DeleteOnTermination=True,
                         VolumeSize=defn.root_disk_size,
-                        VolumeType=ami['BlockDeviceMappings'][0]['Ebs']['VolumeType']
+                        VolumeType=ami.block_device_mappings[0]['Ebs']['VolumeType']
                     )
                 )
                 args['BlockDeviceMappings'].append(root_mapping)
@@ -986,14 +1025,14 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             for device_stored, v in defn.block_device_mapping.iteritems():
                 if not v['disk'].startswith("vol-"): continue
                 # Make note of the placement zone of the volume.
-                volume = nixopsaws.ec2_utils.get_volume_by_id(self._conn, v['disk'])
+                volume = nixopsaws.ec2_utils.get_volume_by_id(self.session(), v['disk'])
                 if not zone:
                     self.log("starting EC2 instance in zone ‘{0}’ due to volume ‘{1}’".format(
-                            volume.zone, v['disk']))
-                    zone = volume.zone
-                elif zone != volume.zone:
+                            volume.availability_zone, v['disk']))
+                    zone = volume.availability_zone
+                elif zone != volume.availability_zone:
                     raise Exception("unable to start EC2 instance ‘{0}’ in zone ‘{1}’ because volume ‘{2}’ is in zone ‘{3}’"
-                                    .format(self.name, zone, v['disk'], volume.zone))
+                                    .format(self.name, zone, v['disk'], volume.availability_zone))
 
             # Do we want an EBS-optimized instance?
             prefer_ebs_optimized = False
@@ -1005,7 +1044,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             ebs_optimized = prefer_ebs_optimized and defn.ebs_optimized
             # Generate a public/private host key.
             if not self.public_host_key:
-                (private, public) = nixops.util.create_key_pair(type=defn.host_key_type())
+                private, public = nixops.util.create_key_pair(type=defn.host_key_type())
                 with self.depl._db:
                     self.public_host_key = public
                     self.private_host_key = private
@@ -1025,7 +1064,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                 self.key_pair = defn.key_pair
                 self.security_groups = defn.security_groups
                 self.placement_group = defn.placement_group
-                self.zone = instance.placement
+                self.zone = instance.placement['AvailabilityZone']
                 self.tenancy = defn.tenancy
                 self.instance_profile = defn.instance_profile
                 self.client_token = None
@@ -1064,7 +1103,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                     ", ".join(set(defn.security_groups)))
             )
 
-        instance_groups = [g.id for g in instance.groups]
+        instance_groups = [g['GroupId'] for g in instance.security_groups]
         if defn.subnet_id:
             new_instance_groups = self.security_groups_to_ids(defn.subnet_id, defn.security_group_ids)
         elif instance.vpc_id:
@@ -1072,7 +1111,8 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
         if instance.vpc_id and set(instance_groups) != set(new_instance_groups):
             self.log("updating security groups from {0} to {1}...".format(instance_groups, new_instance_groups))
-            instance.modify_attribute("groupSet", new_instance_groups)
+            ni = instance.network_interfaces[0]
+            ni.modify_attribute(Groups=new_instance_groups)
 
         if defn.placement_group != (self.placement_group or ""):
             self.warn(
@@ -1083,29 +1123,29 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
         # update iam instance profiles of instance
         if update_instance_profile and (self.instance_profile != defn.instance_profile or check):
-            assocs = self._retry(lambda: self._conn_boto3.describe_iam_instance_profile_associations(Filters=[{ 'Name': 'instance-id', 'Values': [self.vm_id]}])['IamInstanceProfileAssociations'])
+            ec2 = self.session().client('ec2')
+            assocs = self._retry(lambda: ec2.describe_iam_instance_profile_associations(Filters=[{'Name': 'instance-id', 'Values': [self.vm_id]}])['IamInstanceProfileAssociations'])
             if len(assocs) > 0 and self.instance_profile != assocs[0]['IamInstanceProfile']['Arn']:
                 self.log("disassociating instance profile {}".format(assocs[0]['IamInstanceProfile']['Arn']))
-                self._conn_boto3.disassociate_iam_instance_profile(AssociationId=assocs[0]['AssociationId'])
-                nixops.util.check_wait(lambda: len(self._retry(lambda: self._conn_boto3.describe_iam_instance_profile_associations(Filters=[{ 'Name': 'instance-id', 'Values': [self.vm_id]}])['IamInstanceProfileAssociations'])) == 0 )
-
+                ec2.disassociate_iam_instance_profile(AssociationId=assocs[0]['AssociationId'])
+                nixops.util.check_wait(lambda: len(self._retry(lambda: ec2.describe_iam_instance_profile_associations(Filters=[{'Name': 'instance-id', 'Values': [self.vm_id]}])['IamInstanceProfileAssociations'])) == 0)
 
             if defn.instance_profile != "":
                 if defn.instance_profile.startswith('arn:'):
-                    iip = { 'Arn': defn.instance_profile }
+                    iip = {'Arn': defn.instance_profile}
                 else:
-                    iip = { 'Name': defn.instance_profile }
+                    iip = {'Name': defn.instance_profile}
                 self.log("associating instance profile {}".format(defn.instance_profile))
-                self._retry(lambda: self._conn_boto3.associate_iam_instance_profile(IamInstanceProfile=iip, InstanceId=self.vm_id))
+                self._retry(lambda: ec2.associate_iam_instance_profile(IamInstanceProfile=iip, InstanceId=self.vm_id))
 
             with self.depl._db:
                 self.instance_profile = defn.instance_profile
 
         # Reapply tags if they have changed.
         common_tags = defn.tags
-        if defn.owners != []:
+        if defn.owners:
             common_tags['Owners'] = ", ".join(defn.owners)
-        self.update_tags(self.vm_id, user_tags=common_tags, check=check)
+        self.update_tags(self.session(), self.vm_id, user_tags=common_tags, check=check)
 
         # Reapply sourceDestCheck if it has changed.
         if self.source_dest_check != defn.source_dest_check:
@@ -1152,16 +1192,17 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
         # Add disks that were in the original device mapping of image.
         if self.first_boot:
-            for device_stored, dm in self._get_instance().block_device_mapping.items():
-                if device_stored not in self.block_device_mapping and dm.volume_id:
-                    bdm = {'volumeId': dm.volume_id, 'partOfImage': True}
-                    self.update_block_device_mapping(device_stored, bdm) # TODO: it stores root device as sd though its really attached as nvme
+            for device in self._get_instance().block_device_mappings:
+                if device['DeviceName'] not in self.block_device_mapping and device['Ebs']['VolumeId']:
+                    bdm = {'volumeId': device['Ebs']['VolumeId'], 'partOfImage': True}
+                    self.update_block_device_mapping(device['DeviceName'], bdm) # TODO: it stores root device as sd though its really attached as nvme
             self.first_boot = False
 
         # Detect if volumes were manually detached.  If so, reattach
         # them.
+        devices = [device['DeviceName'] for device in self._get_instance().block_device_mappings]
         for device_stored, v in self.block_device_mapping.items():
-            if device_name_to_boto_expected(device_stored) not in self._get_instance().block_device_mapping.keys() and not v.get('needsAttach', False) and v.get('volumeId', None):
+            if device_name_to_boto_expected(device_stored) not in devices and not v.get('needsAttach', False) and v.get('volumeId', None):
                 device_real = device_name_stored_to_real(device_stored)
                 self.warn("device ‘{0}’ was manually detached!".format(device_real))
                 v['needsAttach'] = True
@@ -1170,8 +1211,9 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         # Detect if volumes were manually destroyed.
         for device_stored, v in self.block_device_mapping.items():
             if v.get('needsAttach', False):
-                volume = nixopsaws.ec2_utils.get_volume_by_id(self._conn, v['volumeId'], allow_missing=True)
-                if volume: continue
+                volume = nixopsaws.ec2_utils.get_volume_by_id(self.session(), v['volumeId'], allow_missing=True)
+                if volume:
+                    continue
                 if device_stored not in defn.block_device_mapping:
                     self.warn("forgetting about volume ‘{0}’ that no longer exists and is no longer needed by the deployment specification".format(v['volumeId']))
                 else:
@@ -1183,16 +1225,18 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                 self.update_block_device_mapping(device_stored, None)
 
         # Create missing volumes.
+        ec2 = self.session().client('ec2')
         for device_stored, v in defn.block_device_mapping.iteritems():
             device_real = device_name_stored_to_real(device_stored)
 
             volume = None
             if v['disk'] == '':
-                if device_stored in self.block_device_mapping: continue
+                if device_stored in self.block_device_mapping:
+                    continue
                 self.log("creating EBS volume of {0} GiB...".format(v['size']))
                 ebs_encrypt = v.get('encryptionType', "luks") == "ebs"
-                volume = self._conn.create_volume(size=v['size'], zone=self.zone, volume_type=v['volumeType'], iops=v['iops'], encrypted=ebs_encrypt)
-                v['volumeId'] = volume.id
+                volume = ec2.create_volume(Size=v['size'], AvailabilityZone=self.zone, VolumeType=v['volumeType'], Iops=v['iops'], Encrypted=ebs_encrypt)
+                v['volumeId'] = volume['VolumeId']
 
             elif v['disk'].startswith("vol-"):
                 if device_stored in self.block_device_mapping:
@@ -1216,10 +1260,11 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                 v['volumeId'] = res.volume_id
 
             elif v['disk'].startswith("snap-"):
-                if device_stored in self.block_device_mapping: continue
+                if device_stored in self.block_device_mapping:
+                    continue
                 self.log("creating volume from snapshot ‘{0}’...".format(v['disk']))
-                volume = self._conn.create_volume(size=v['size'], snapshot=v['disk'], zone=self.zone, volume_type=v['volumeType'], iops=v['iops'])
-                v['volumeId'] = volume.id
+                volume = ec2.create_volume(Size=v['size'], SnapshotId=v['disk'], AvailabilityZone=self.zone, VolumeType=v['volumeType'], Iops=v['iops'])
+                v['volumeId'] = volume['VolumeId']
 
             else:
                 if device_stored in self.block_device_mapping:
@@ -1242,24 +1287,27 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             # in-use).  Doing this after updating the device mapping
             # state, to make it recoverable in case an exception
             # happens (e.g. in other machine's deployments).
-            if volume: nixopsaws.ec2_utils.wait_for_volume_available(self._conn, volume.id, self.logger)
+            if volume:
+                nixopsaws.ec2_utils.wait_for_volume_available(self.session(), volume.id, self.logger)
 
         # Always apply tags to the volumes we just created.
+        ec2 = self.session().client('ec2')
         for device_stored, v in self.block_device_mapping.items():
             device_real = device_name_stored_to_real(device_stored)
 
             if not (('disk' in v and not (v['disk'].startswith("ephemeral")
                                           or v['disk'].startswith("res-")
                                           or v['disk'].startswith("vol-")))
-                    or 'partOfImage' in v): continue
+                    or 'partOfImage' in v):
+                continue
             volume_tags = {}
             volume_tags.update(common_tags)
             volume_tags.update(defn.tags)
             volume_tags['Name'] = "{0} [{1} - {2}]".format(self.depl.description, self.name, device_real)
-            self._retry(lambda: self._conn.create_tags([v['volumeId']], volume_tags))
+
+            self._retry(lambda: ec2.create_tags(Resources=[v['volumeId']], Tags=key_value_to_ec2_key_value(volume_tags)))
 
         # Attach missing volumes.
-
         for device_stored, v in self.sorted_block_device_mapping():
             if v.get('needsAttach', False):
                 self.attach_volume(device_stored, v['volumeId'])
@@ -1320,7 +1368,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             raise Exception('hosted zone for {0} not found'.format(hosted_zone))
 
         # use hosted zone with longest match
-        zones = sorted(zones, cmp=lambda a, b: cmp(len(a.Name), len(b.Name)), reverse=True)
+        zones = sorted(zones, key=lambda x: len(x.Name), reverse=True)
         zoneid = zones[0]['Id'].split("/")[2]
         dns_name = '{0}.'.format(self.dns_hostname)
 
@@ -1375,8 +1423,11 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
     def destroy(self, wipe=False):
         self._cancel_spot_request()
 
-        if not (self.vm_id or self.client_token): return True
-        if not self.depl.logger.confirm("are you sure you want to destroy EC2 machine ‘{0}’?".format(self.name)): return False
+        if not (self.vm_id or self.client_token):
+            return True
+
+        if not self.depl.logger.confirm("are you sure you want to destroy EC2 machine ‘{0}’?".format(self.name)):
+            return False
 
         if wipe:
             log.warn("wipe is not supported")
@@ -1387,22 +1438,25 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         # The latter allows us to destroy instances that were "leaked"
         # in create() due to it being interrupted after the instance
         # was created but before it registered the ID in the database.
-        self.connect()
         instance = None
         if self.vm_id:
             instance = self._get_instance(allow_missing=True)
         else:
-            reservations = self._conn.get_all_instances(filters={'client-token': self.client_token})
+            ec2c = self.session().client('ec2')
+            ec2r = self.session().resource('ec2')
+            reservations = ec2c.describe_instances(Filters=[{'Name': 'client-token', 'Values': [self.client_token]}])['Reservations']
             if len(reservations) > 0:
-                instance = reservations[0].instances[0]
+                self.vm_id = reservations[0]['Instances'][0]['InstanceId']
+                instance = ec2r.Instance(self.vm_id)
 
         if instance:
             instance.terminate()
 
             # Wait until it's really terminated.
             while True:
-                self.log_continue("[{0}] ".format(instance.state))
-                if instance.state == "terminated": break
+                self.log_continue("[{0}] ".format(instance.state['Name']))
+                if instance.state['Name'] == "terminated":
+                    break
                 time.sleep(3)
                 instance = self._get_instance(update=True)
 
@@ -1418,8 +1472,9 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
         return True
 
-
     def stop(self):
+        # type: () -> None
+
         if not self._booted_from_ebs():
             self.warn("cannot stop non-EBS-backed instance")
             return
@@ -1436,27 +1491,28 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
         # Wait until it's really stopped.
         def check_stopped():
+            # type: () -> bool
             instance = self._get_instance(update=True)
             self.log_continue("[{0}] ".format(instance.state))
-            if instance.state == "stopped":
+            if instance.state['Name'] == "stopped":
                 return True
-            if instance.state not in {"running", "stopping"}:
+            if instance.state['Name'] not in {"running", "stopping"}:
                 raise Exception(
                     "EC2 instance ‘{0}’ failed to stop (state is ‘{1}’)"
                     .format(self.vm_id, instance.state))
             return False
 
-        if not nixops.util.check_wait(check_stopped, initial=3, max_tries=300, exception=False): # = 15 min
+        if not nixops.util.check_wait(check_stopped, initial=3, max_tries=300, exception=False):  # = 15 min
             # If stopping times out, then do an unclean shutdown.
             self.log_end("(timed out)")
             self.log_start("force-stopping EC2 machine... ")
-            instance.stop(force=True)
-            if not nixops.util.check_wait(check_stopped, initial=3, max_tries=100, exception=False): # = 5 min
+            instance.stop(Force=True)
+            if not nixops.util.check_wait(check_stopped, initial=3, max_tries=100, exception=False):  # = 5 min
                 # Amazon docs suggest doing a force stop twice...
                 self.log_end("(timed out)")
                 self.log_start("force-stopping EC2 machine... ")
-                instance.stop(force=True)
-                nixops.util.check_wait(check_stopped, initial=3, max_tries=100) # = 5 min
+                instance.stop(Force=True)
+                nixops.util.check_wait(check_stopped, initial=3, max_tries=100)  # = 5 min
 
         self.log_end("")
 
@@ -1492,7 +1548,6 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
         self.wait_for_ssh(check=True)
         self.send_keys()
-
 
     def _check(self, res):
         if not self.vm_id:

--- a/nixopsaws/backends/ec2.py
+++ b/nixopsaws/backends/ec2.py
@@ -370,14 +370,14 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
         return self._cached_instance
 
-
     def _get_snapshot_by_id(self, snapshot_id):
+        # type: (str) -> Any
         """Get snapshot object by instance id."""
-        self.connect()
-        snapshots = self._conn.get_all_snapshots([snapshot_id])
-        if len(snapshots) != 1:
-            raise Exception("unable to find snapshot ‘{0}’".format(snapshot_id))
-        return snapshots[0]
+        ec2 = self.session().resource('ec2')
+        snapshot = ec2.Snapshot(snapshot_id)
+        snapshot.load()
+
+        return snapshot
 
     def _wait_for_ip(self):
         self.log_start("waiting for IP address... ".format(self.name))
@@ -431,11 +431,13 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             x[k] = v
         self.block_device_mapping = x
 
-
     def get_backups(self):
-        if not self.region: return {}
-        self.connect()
-        backups = {}
+        # type: () -> Dict[str, Dict[str, Any]]
+
+        if not self.region:
+            return {}
+
+        backups = {}  # type: Dict[str, Dict[str, Any]]
         current_volumes = set([v['volumeId'] for v in self.block_device_mapping.values()])
         for b_id, b in self.backups.items():
             b = {device_name_stored_to_real(device): snap for device, snap in b.items()}
@@ -449,22 +451,26 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                 if snapshot_id is not None:
                     try:
                         snapshot = self._get_snapshot_by_id(snapshot_id)
-                        snapshot_status = snapshot.update()
+                        snapshot_status = snapshot.progress
                         info.append("progress[{0},{1},{2}] = {3}".format(self.name, device_real, snapshot_id, snapshot_status))
                         if snapshot_status != '100%':
                             backup_status = "running"
-                    except boto.exception.EC2ResponseError as e:
-                        if e.error_code != "InvalidSnapshot.NotFound": raise
+                    except botocore.exceptions.ClientError as e:
+                        if e.response['Error']['Code'] != "InvalidSnapshot.NotFound":
+                            raise
+
                         info.append("{0} - {1} - {2} - Snapshot has disappeared".format(self.name, device_real, snapshot_id))
                         backup_status = "unavailable"
+
             backups[b_id]['status'] = backup_status
             backups[b_id]['info'] = info
+
         return backups
 
-
     def remove_backup(self, backup_id, keep_physical=False):
+        # type: (str, bool) -> None
+
         self.log('removing backup {0}'.format(backup_id))
-        self.connect()
         _backups = self.backups
         if not backup_id in _backups.keys():
             self.warn('backup {0} not found, skipping'.format(backup_id))
@@ -483,49 +489,60 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             _backups.pop(backup_id)
             self.backups = _backups
 
+    def backup(self, defn, backup_id, devices=None):
+        # type: (EC2Definition, str, Optional[List[str]]) -> None
 
-    def backup(self, defn, backup_id, devices=[]):
-        self.connect()
+        if devices is None:
+            devices = []
 
         self.log("backing up machine ‘{0}’ using id ‘{1}’".format(self.name, backup_id))
         backup = {}
         _backups = self.backups
 
+        ec2 = self.session().client('ec2')
         for device_stored, v in self.block_device_mapping.items():
             device_real = device_name_stored_to_real(device_stored)
 
-            if devices == [] or device_real in devices:
-                snapshot = self._retry(lambda: self._conn.create_snapshot(volume_id=v['volumeId']))
-                self.log("+ created snapshot of volume ‘{0}’: ‘{1}’".format(v['volumeId'], snapshot.id))
+            if not devices or device_real in devices:
+                snapshot = self._retry(lambda: ec2.create_snapshot(VolumeId=v['volumeId']))
+                self.log("+ created snapshot of volume ‘{0}’: ‘{1}’".format(v['volumeId'], snapshot['SnapshotId']))
 
-                snapshot_tags = {}
+                snapshot_tags = {}  # type: Dict[str, str]
                 snapshot_tags.update(defn.tags)
                 snapshot_tags.update(self.get_common_tags())
                 snapshot_tags['Name'] = "{0} - {3} [{1} - {2}]".format(self.depl.description, self.name, device_stored, backup_id)
 
-                self._retry(lambda: self._conn.create_tags([snapshot.id], snapshot_tags))
-                backup[device_stored] = snapshot.id
+                self._retry(lambda: ec2.create_tags(Resources=[snapshot['SnapshotId']], Tags=key_value_to_ec2_key_value(snapshot_tags)))
+                backup[device_stored] = snapshot['SnapshotId']
 
         _backups[backup_id] = backup
         self.backups = _backups
 
     # devices - array of dictionaries, keys - /dev/nvme or /dev/xvd device name, values - device options
-    def restore(self, defn, backup_id, devices=[]):
+    def restore(self, defn, backup_id, devices=None):
+        # type: (EC2Definition, str, Optional[List[str]]) -> None
+
+        if devices is None:
+            devices = []
+
         self.stop()
 
         self.log("restoring machine ‘{0}’ to backup ‘{1}’".format(self.name, backup_id))
         for d in devices:
             self.log(" - {0}".format(d))
 
+        ec2 = self.session().client('ec2')
+        ec2r = self.session().resource('ec2')
+
         for device_stored, v in self.sorted_block_device_mapping():
             device_real = device_name_stored_to_real(device_stored)
 
-            if devices == [] or device_real in devices:
+            if not devices or device_real in devices:
                 # detach disks
-                volume = nixopsaws.ec2_utils.get_volume_by_id(self.connect(), v['volumeId'])
-                if volume and volume.update() == "in-use":
+                volume = nixopsaws.ec2_utils.get_volume_by_id(self.session(), v['volumeId'])
+                if volume and volume.state == "in-use":
                     self.log("detaching volume from ‘{0}’".format(self.name))
-                    volume.detach()
+                    volume.detach_from_instance()
 
                 # attach backup disks
                 snapshot_id = self.backups[backup_id][device_stored]
@@ -533,19 +550,20 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
                 self.wait_for_snapshot_to_become_completed(snapshot_id)
 
-                new_volume = self._conn.create_volume(size=0, snapshot=snapshot_id, zone=self.zone)
+                res = ec2.create_volume(SnapshotId=snapshot_id, AvailabilityZone=self.zone)
+                new_volume = ec2r.Volume(res['VolumeId'])
 
                 # Check if original volume is available, aka detached from the machine.
                 if volume:
-                    nixopsaws.ec2_utils.wait_for_volume_available(self._conn, volume.id, self.logger)
+                    nixopsaws.ec2_utils.wait_for_volume_available(self.session(), volume.id, self.logger)
 
                 # Check if new volume is available.
-                nixopsaws.ec2_utils.wait_for_volume_available(self._conn, new_volume.id, self.logger)
+                nixopsaws.ec2_utils.wait_for_volume_available(self.session(), new_volume.id, self.logger)
 
                 self.log("attaching volume ‘{0}’ to ‘{1}’ as {2}".format(new_volume.id, self.name, device_real))
 
-                device_that_boto_expects = device_name_to_boto_expected(device_real) # boto expects only sd names
-                new_volume.attach(self.vm_id, device_that_boto_expects)
+                device_that_boto_expects = device_name_to_boto_expected(device_real)  # boto expects only sd names
+                new_volume.attach_to_instance(InstanceId=self.vm_id, Device=device_that_boto_expects)
 
                 new_v = self.block_device_mapping[device_stored]
 
@@ -557,7 +575,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
     def wait_for_snapshot_to_become_completed(self, snapshot_id):
         def check_completed():
-            res = self._get_snapshot_by_id(snapshot_id).status
+            res = self._get_snapshot_by_id(snapshot_id).state
             self.log_continue("[{0}] ".format(res))
             return res == 'completed'
 
@@ -1405,17 +1423,26 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         # this due to eventual consistency
         self._retry_route53(lambda: changes.commit(), error_codes=['InvalidChangeBatch'])
 
-
     def _delete_volume(self, volume_id, allow_keep=False):
+        # type: (str, bool) -> None
+
         if not self.depl.logger.confirm("are you sure you want to destroy EBS volume ‘{0}’?".format(volume_id)):
             if allow_keep:
                 return
             else:
                 raise Exception("not destroying EBS volume ‘{0}’".format(volume_id))
         self.log("destroying EBS volume ‘{0}’...".format(volume_id))
-        volume = nixopsaws.ec2_utils.get_volume_by_id(self.connect(), volume_id, allow_missing=True)
-        if not volume: return
-        nixops.util.check_wait(lambda: volume.update() == 'available')
+        volume = nixopsaws.ec2_utils.get_volume_by_id(self.session(), volume_id, allow_missing=True)
+        if not volume:
+            return
+
+        def check_volume_available(volume):
+            # type: (Any) -> bool
+
+            volume.reload()
+            return volume.state == 'available'
+
+        nixops.util.check_wait(lambda: check_volume_available(volume))
         volume.delete()
 
 
@@ -1492,7 +1519,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         def check_stopped():
             # type: () -> bool
             instance = self._get_instance(update=True)
-            self.log_continue("[{0}] ".format(instance.state))
+            self.log_continue("[{0}] ".format(instance.state['Name']))
             if instance.state['Name'] == "stopped":
                 return True
             if instance.state['Name'] not in {"running", "stopping"}:

--- a/nixopsaws/ec2_utils.py
+++ b/nixopsaws/ec2_utils.py
@@ -1,21 +1,35 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+
 import os
 import time
 import random
+
+from botocore import credentials
+from typing import Optional, Callable, List, TypeVar, Dict, Mapping, TYPE_CHECKING, Container
 
 import nixops.util
 
 import boto3
 import boto.ec2
 import boto.vpc
+import logging
 from boto.exception import EC2ResponseError
 from boto.exception import SQSError
 from boto.exception import BotoServerError
 from botocore.exceptions import ClientError
 from boto.pyami.config import Config
 
-import botocore
+import botocore.session
+import botocore.exceptions
+
+from nixops.resources import ResourceState
+
+if TYPE_CHECKING:
+    from .resources.ec2_common import EC2CommonState
+    T = TypeVar('T')
+
 
 def fetch_aws_secret_key(access_key_id):
     """
@@ -57,26 +71,53 @@ def fetch_aws_secret_key(access_key_id):
     # Get the first existing access-secret key pair
     credentials = next( (keys for keys in sources if keys and keys[1]), None)
 
-    if not credentials:
-        raise Exception("please set $EC2_SECRET_KEY or $AWS_SECRET_ACCESS_KEY, or add the key for ‘{0}’ to ~/.ec2-keys or ~/.aws/credentials"
-                        .format(access_key_id))
-
     return credentials
 
-def connect(region, access_key_id):
+
+def session(**kwargs):
+    # type: (**str) -> boto3.Session
+    # TODO: remove me
+    print("session", kwargs)
+
+    kwargs = kwargs.copy()
+    profile = kwargs.pop('profile_name', None)
+
+    # cache MFA session between runs so we don't have to enter the code every time
+    cli_cache = os.path.join(os.path.expanduser('~'), '.aws/cli/cache')
+    session = botocore.session.Session(profile=profile)
+    resolver = session.get_component('credential_provider')
+    provider = resolver.get_provider('assume-role')
+    provider.cache = credentials.JSONFileCache(cli_cache)
+
+    return boto3.session.Session(botocore_session=session, **kwargs)
+
+
+def connect(region, profile, access_key_id):
     """Connect to the specified EC2 region using the given access key."""
+    print("connect", region, profile, access_key_id)
     assert region
-    (access_key_id, secret_access_key) = fetch_aws_secret_key(access_key_id)
-    conn = boto.ec2.connect_to_region(
-        region_name=region, aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
+    credentials = fetch_aws_secret_key(access_key_id)
+    if credentials:
+        (access_key_id, secret_access_key) = credentials
+        conn = boto.ec2.connect_to_region(
+            region_name=region, aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
+    else:
+        conn = boto.ec2.connect_to_region(region_name=region, profile_name=profile)
+
     if not conn:
         raise Exception("invalid EC2 region ‘{0}’".format(region))
+
     return conn
 
-def connect_ec2_boto3(region, access_key_id):
+def connect_ec2_boto3(region, profile, access_key_id):
+    print("connect3", region, profile, access_key_id)
     assert region
-    (access_key_id, secret_access_key) = fetch_aws_secret_key(access_key_id)
-    client = boto3.session.Session().client('ec2', region_name=region, aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
+    credentials = fetch_aws_secret_key(access_key_id)
+    if credentials:
+        (access_key_id, secret_access_key) = credentials
+        client = boto3.session.Session().client('ec2', region_name=region, aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
+    else:
+        client = boto3.session.Session(region_name=region, profile_name=profile)
     return client
 
 def connect_vpc(region, access_key_id):
@@ -94,31 +135,26 @@ def get_access_key_id():
     return os.environ.get('EC2_ACCESS_KEY') or os.environ.get('AWS_ACCESS_KEY_ID')
 
 
-def retry(f, error_codes=[], logger=None):
+def retry(f, error_codes=None, logger=None):
+    # type: (Callable[[], T], Optional[List[str]], Optional[EC2CommonState]) -> T
     """
         Retry function f up to 7 times. If error_codes argument is empty list, retry on all EC2 response errors,
         otherwise, only on the specified error codes.
     """
+    if error_codes is None:
+        error_codes = []
 
     def handle_exception(e):
-        if hasattr(e, 'error_code'):
-            err_code = e.error_code
-            err_msg = e.error_message
-        else:
-            err_code = e.response['Error']['Code']
-            err_msg = e.response['Error']['Message']
+        # type: (botocore.exceptions.ClientError) -> None
 
-        if i == num_retries or (error_codes != [] and not err_code in error_codes):
-            raise e
-        if logger is not None:
-            logger.log("got (possibly transient) EC2 error code '{0}': {1}. retrying...".format(err_code, err_msg))
+        err_code = e.response['Error']['Code']
+        err_msg = e.response['Error']['Message']
 
-    def handle_boto3_exception(e):
-        if i == num_retries:
+        if i == num_retries or (error_codes and not err_code in error_codes):
             raise e
+
         if logger is not None:
-            if hasattr(e, 'response'):
-                logger.log("got (possibly transient) EC2 error '{}', retrying...".format(str(e.response['Error'])))
+            logger.logger.log("got (possibly transient) EC2 error code '%s': %s. retrying..." % (err_code, err_msg))
 
     i = 0
     num_retries = 7
@@ -128,64 +164,63 @@ def retry(f, error_codes=[], logger=None):
 
         try:
             return f()
-        except EC2ResponseError as e:
-            handle_exception(e)
-        except SQSError as e:
-            handle_exception(e)
         except ClientError as e:
-            handle_boto3_exception(e)
-        except BotoServerError as e:
-            if e.error_code == "RequestLimitExceeded":
+            if e.response['Error']['Code'] == "RequestLimitExceeded":
                 num_retries += 1
-            else:
-                handle_exception(e)
-        except botocore.exceptions.ClientError as e:
+                continue
             handle_exception(e)
-        except Exception as e:
-            raise e
 
         time.sleep(next_sleep)
 
 
-def get_volume_by_id(conn, volume_id, allow_missing=False):
+def get_volume_by_id(session, volume_id, allow_missing=False):
+    # type: (boto3.Session, str, bool) -> Optional[...]
     """Get volume object by volume id."""
+    ec2 = session.resource('ec2')
+    volume = ec2.Volume(volume_id)
     try:
-        volumes = conn.get_all_volumes([volume_id])
-        if len(volumes) != 1:
-            raise Exception("unable to find volume ‘{0}’".format(volume_id))
-        return volumes[0]
-    except boto.exception.EC2ResponseError as e:
-        if e.error_code != "InvalidVolume.NotFound": raise
-    return None
+        volume.load()
+        return volume
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == 'InvalidVolume.NotFound':
+            return None
+        raise
 
 
-def wait_for_volume_available(conn, volume_id, logger, states=['available']):
+def wait_for_volume_available(session, volume_id, logger, states=None):
+    # type: (boto3.Session, str, ResourceState, Optional[Container[str]]) -> None
     """Wait for an EBS volume to become available."""
+
+    if states is None:
+        states = ['available']
 
     logger.log_start("waiting for volume ‘{0}’ to become available... ".format(volume_id))
 
     def check_available():
+        # type: () -> bool
+
         # Allow volume to be missing due to eventual consistency.
-        volume = get_volume_by_id(conn, volume_id, allow_missing=True)
+        volume = get_volume_by_id(session, volume_id, allow_missing=True)
         logger.log_continue("[{0}] ".format(volume.status))
-        return volume.status in states
+        return volume.state in states
 
     nixops.util.check_wait(check_available, max_tries=90)
 
     logger.log_end('')
 
 
-def name_to_security_group(conn, name, vpc_id):
+def name_to_security_group(session, name, vpc_id):
+    # type: (boto3.Session, str, str) -> str
     if not vpc_id or name.startswith('sg-'):
         return name
 
-    id = None
-    for sg in conn.get_all_security_groups(filters={'group-name':name, 'vpc-id': vpc_id}):
-        if sg.name == name:
-            id = sg.id
-            return id
+    ec2 = session.client('ec2')
+    for sg in ec2.describe_security_groups(Filters=[{'Name': 'group-name', 'Values': [name]}, {'Name': 'vpc-id', 'Values': [vpc_id]}])['SecurityGroups']:
+        if sg['GroupName'] == name:
+            return sg['GroupId']
+    else:
+        raise Exception("could not resolve security group name '{0}' in VPC '{1}'".format(name, vpc_id))
 
-    raise Exception("could not resolve security group name '{0}' in VPC '{1}'".format(name, vpc_id))
 
 def id_to_security_group_name(conn, sg_id, vpc_id):
     name = None
@@ -194,3 +229,9 @@ def id_to_security_group_name(conn, sg_id, vpc_id):
             name = sg.name
             return name
     raise Exception("could not resolve security group id '{0}' in VPC '{1}'".format(sg_id, vpc_id))
+
+
+def key_value_to_ec2_key_value(kv):
+    # type: (Mapping[str, str]) -> List[Dict[str, str]]
+
+    return [{'Key': key, 'Value': value} for key, value in kv.items()]

--- a/nixopsaws/ec2_utils.py
+++ b/nixopsaws/ec2_utils.py
@@ -193,7 +193,7 @@ def wait_for_volume_available(session, volume_id, logger, states=None):
         # Allow volume to be missing due to eventual consistency.
         volume = get_volume_by_id(session, volume_id, allow_missing=True)
         if volume:
-            logger.log_continue("[{0}] ".format(volume.status))
+            logger.log_continue("[{0}] ".format(volume.state))
             return volume.state in states
         else:
             logger.log_continue("[missing] ")

--- a/nixopsaws/ec2_utils.py
+++ b/nixopsaws/ec2_utils.py
@@ -3,29 +3,20 @@
 from __future__ import absolute_import
 
 import os
-import time
 import random
+import time
 
-from botocore import credentials
-from typing import Optional, Callable, List, TypeVar, Dict, Mapping, TYPE_CHECKING, Container, Any, cast, NoReturn, \
-    Union
-
-import nixops.util
-
-import boto3
 import boto.ec2
 import boto.vpc
-import logging
-from boto.exception import EC2ResponseError
-from boto.exception import SQSError
-from boto.exception import BotoServerError
-from botocore.exceptions import ClientError
-from boto.pyami.config import Config
-
-import botocore.session
+import boto3
 import botocore.exceptions
-
+import botocore.session
+import nixops.util
+from boto.pyami.config import Config
+from botocore import credentials
+from botocore.exceptions import ClientError
 from nixops.resources import ResourceState
+from typing import Any, Callable, Container, Dict, List, Mapping, Optional, TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
     from .resources.ec2_common import EC2CommonState
@@ -77,8 +68,6 @@ def fetch_aws_secret_key(access_key_id):
 
 def session(**kwargs):
     # type: (**str) -> boto3.Session
-    # TODO: remove me
-    print("session", kwargs)
 
     kwargs = kwargs.copy()
     profile = kwargs.pop('profile_name', None)
@@ -95,7 +84,6 @@ def session(**kwargs):
 
 def connect(region, profile, access_key_id):
     """Connect to the specified EC2 region using the given access key."""
-    print("connect", region, profile, access_key_id)
     assert region
     credentials = fetch_aws_secret_key(access_key_id)
     if credentials:
@@ -111,7 +99,6 @@ def connect(region, profile, access_key_id):
     return conn
 
 def connect_ec2_boto3(region, profile, access_key_id):
-    print("connect3", region, profile, access_key_id)
     assert region
     credentials = fetch_aws_secret_key(access_key_id)
     if credentials:

--- a/nixopsaws/resources/ebs_volume.py
+++ b/nixopsaws/resources/ebs_volume.py
@@ -2,14 +2,17 @@
 
 # Automatic provisioning of AWS EBS volumes.
 
+from __future__ import absolute_import
+
 import time
 import boto.ec2
 import nixops.util
 import nixopsaws.ec2_utils
 import nixops.resources
 import botocore.exceptions
-import ec2_common
+from . import ec2_common
 
+import boto3
 
 class EBSVolumeDefinition(nixops.resources.ResourceDefinition):
     """Definition of an EBS volume."""
@@ -26,10 +29,11 @@ class EBSVolumeDefinition(nixops.resources.ResourceDefinition):
         return "{0}".format(self.get_type())
 
 
-class EBSVolumeState(nixops.resources.ResourceState, ec2_common.EC2CommonState):
+class EBSVolumeState(ec2_common.EC2CommonState, nixops.resources.ResourceState):
     """State of an EBS volume."""
 
     state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+    profile = nixops.util.attr_property("ec2.profile", None)
     access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
     region = nixops.util.attr_property("ec2.region", None)
     zone = nixops.util.attr_property("ec2.zone", None)
@@ -46,8 +50,7 @@ class EBSVolumeState(nixops.resources.ResourceState, ec2_common.EC2CommonState):
 
     def __init__(self, depl, name, id):
         nixops.resources.ResourceState.__init__(self, depl, name, id)
-        self._conn = None
-        self._conn_boto3 = None
+        self._session = None  # type: boto3.Session
 
 
     def _exists(self):
@@ -64,6 +67,17 @@ class EBSVolumeState(nixops.resources.ResourceState, ec2_common.EC2CommonState):
     def resource_id(self):
         return self.volume_id
 
+    def session(self):
+        # type: () -> boto3.Session
+
+        if self._session is None:
+            self._session = boto3.session.Session(
+                region_name=self.region,
+                profile_name=self.profile,
+                aws_access_key_id=self.access_key_id
+            )
+
+        return self._session
 
     def connect(self, region):
         if self._conn: return self._conn
@@ -154,7 +168,7 @@ class EBSVolumeState(nixops.resources.ResourceState, ec2_common.EC2CommonState):
                 self.log("volume ID is ‘{0}’".format(self.volume_id))
 
         if self.state == self.STARTING or check:
-            self.update_tags(self.volume_id, user_tags=defn.config['tags'], check=check)
+            self.update_tags(self.session(), self.volume_id, user_tags=defn.config['tags'], check=check)
             nixopsaws.ec2_utils.wait_for_volume_available(
                 self._conn, self.volume_id, self.logger,
                 states=['available', 'in-use'])

--- a/nixopsaws/resources/ebs_volume.py
+++ b/nixopsaws/resources/ebs_volume.py
@@ -4,15 +4,14 @@
 
 from __future__ import absolute_import
 
-import time
-import boto.ec2
-import nixops.util
-import nixopsaws.ec2_utils
-import nixops.resources
+import boto3
 import botocore.exceptions
+import nixops.resources
+import nixops.util
+
+import nixopsaws.ec2_utils
 from . import ec2_common
 
-import boto3
 
 class EBSVolumeDefinition(nixops.resources.ResourceDefinition):
     """Definition of an EBS volume."""

--- a/nixopsaws/resources/ec2_common.py
+++ b/nixopsaws/resources/ec2_common.py
@@ -1,14 +1,21 @@
+from __future__ import absolute_import
+
 import socket
 import getpass
 
 import boto3
+from typing import Dict, Mapping, Optional, Callable
 
 import nixops.util
 import nixops.resources
 from nixops.diff import Diff, Handler
 import nixopsaws.ec2_utils
 
-class EC2CommonState():
+from nixops.resources import ResourceState
+from ..ec2_utils import key_value_to_ec2_key_value
+
+
+class EC2CommonState(ResourceState):
 
     COMMON_EC2_RESERVED = ['accessKeyId', 'ec2.tags']
 
@@ -18,6 +25,7 @@ class EC2CommonState():
     tags = nixops.util.attr_property("ec2.tags", {}, 'json')
 
     def get_common_tags(self):
+        # type: () -> Dict[str, str]
         tags = {'CharonNetworkUUID': self.depl.uuid,
                 'CharonMachineName': self.name,
                 'CharonStateFile': "{0}@{1}:{2}".format(getpass.getuser(), socket.gethostname(), self.depl._db.db_file)}
@@ -26,9 +34,15 @@ class EC2CommonState():
         return tags
 
     def get_default_name_tag(self):
+        # type: () -> str
         return "{0} [{1}]".format(self.depl.description, self.name)
 
-    def update_tags_using(self, updater, user_tags={}, check=False):
+    def update_tags_using(self, updater, user_tags=None, check=False):
+        # type: (Callable[[Mapping[str, str]], None], Optional[Mapping[str, str]], bool) -> None
+
+        if user_tags is None:
+            user_tags = {}
+
         tags = {'Name': self.get_default_name_tag()}
         tags.update(user_tags)
         tags.update(self.get_common_tags())
@@ -37,11 +51,19 @@ class EC2CommonState():
             updater(tags)
             self.tags = tags
 
-    def update_tags(self, id, user_tags={}, check=False):
+    def update_tags(self, session, id, user_tags=None, check=False):
+        # type: (boto3.Session, str, Optional[Dict[str, str]], bool) -> None
+
+        if user_tags is None:
+            user_tags = {}
 
         def updater(tags):
+            # type: (Mapping[str, str]) -> None
+
+            ec2 = session.client('ec2')
+
             # FIXME: handle removing tags.
-            self._retry(lambda: self._conn.create_tags([id], tags))
+            self._retry(lambda: ec2.create_tags(Resources=[id], Tags=key_value_to_ec2_key_value(tags)))
 
         self.update_tags_using(updater, user_tags=user_tags, check=check)
 

--- a/nixopsaws/resources/ec2_common.py
+++ b/nixopsaws/resources/ec2_common.py
@@ -1,17 +1,14 @@
 from __future__ import absolute_import
 
-import socket
 import getpass
+import socket
 
 import boto3
-from typing import Dict, Mapping, Optional, Callable
-
 import nixops.util
-import nixops.resources
-from nixops.diff import Diff, Handler
-import nixopsaws.ec2_utils
-
 from nixops.resources import ResourceState
+from typing import Callable, Dict, Mapping, Optional
+
+import nixopsaws.ec2_utils
 from ..ec2_utils import key_value_to_ec2_key_value
 
 

--- a/nixopsaws/resources/ec2_keypair.py
+++ b/nixopsaws/resources/ec2_keypair.py
@@ -5,11 +5,10 @@
 from __future__ import absolute_import
 
 import boto3
-import botocore.client
-
-import nixopsaws.ec2_utils
 import nixops.resources
 import nixops.util
+
+import nixopsaws.ec2_utils
 
 
 class EC2KeyPairDefinition(nixops.resources.ResourceDefinition):

--- a/nixopsaws/resources/ec2_keypair.py
+++ b/nixopsaws/resources/ec2_keypair.py
@@ -2,9 +2,14 @@
 
 # Automatic provisioning of EC2 key pairs.
 
-import nixops.util
-import nixops.resources
+from __future__ import absolute_import
+
+import boto3
+import botocore.client
+
 import nixopsaws.ec2_utils
+import nixops.resources
+import nixops.util
 
 
 class EC2KeyPairDefinition(nixops.resources.ResourceDefinition):
@@ -12,19 +17,25 @@ class EC2KeyPairDefinition(nixops.resources.ResourceDefinition):
 
     @classmethod
     def get_type(cls):
+        # type: () -> str
         return "ec2-keypair"
 
     @classmethod
     def get_resource_type(cls):
+        # type: () -> str
         return "ec2KeyPairs"
 
     def __init__(self, xml):
-        nixops.resources.ResourceDefinition.__init__(self, xml)
+        # type: (...) -> None
+        super(EC2KeyPairDefinition, self).__init__(xml)
+
         self.keypair_name = xml.find("attrs/attr[@name='name']/string").get("value")
         self.region = xml.find("attrs/attr[@name='region']/string").get("value")
+        self.profile = xml.find("attrs/attr[@name='profile']/string").get("value")
         self.access_key_id = xml.find("attrs/attr[@name='accessKeyId']/string").get("value")
 
     def show_type(self):
+        # type: () -> str
         return "{0} [{1}]".format(self.get_type(), self.region)
 
 
@@ -35,104 +46,94 @@ class EC2KeyPairState(nixops.resources.ResourceState):
     keypair_name = nixops.util.attr_property("ec2.keyPairName", None)
     public_key = nixops.util.attr_property("publicKey", None)
     private_key = nixops.util.attr_property("privateKey", None)
+    profile = nixops.util.attr_property("ec2.profile", None)
     access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
     region = nixops.util.attr_property("ec2.region", None)
-
 
     @classmethod
     def get_type(cls):
         return "ec2-keypair"
 
-
     def __init__(self, depl, name, id):
-        nixops.resources.ResourceState.__init__(self, depl, name, id)
-        self._conn = None
-
+        super(EC2KeyPairState, self).__init__(depl, name, id)
+        self._session = None  # type: boto3.session.Session
 
     def show_type(self):
         s = super(EC2KeyPairState, self).show_type()
-        if self.region: s = "{0} [{1}]".format(s, self.region)
-        return s
+        if self.region:
+            s = "{0} [{1}]".format(s, self.region)
 
+        return s
 
     @property
     def resource_id(self):
         return self.keypair_name
 
-
-    def get_definition_prefix(self):
+    @staticmethod
+    def get_definition_prefix():
         return "resources.ec2KeyPairs."
 
+    def session(self):
+        # type: () -> boto3.Session
 
-    def connect(self):
-        if self._conn: return
-        self._conn = nixopsaws.ec2_utils.connect(self.region, self.access_key_id)
+        if not self._session:
+            self._session = nixopsaws.ec2_utils.session(**{
+                "region_name": self.region,
+                "profile_name": self.profile,
+                "aws_access_key_id": self.access_key_id
+            })
 
+        return self._session
 
     def create(self, defn, check, allow_reboot, allow_recreate):
+        # type: (EC2KeyPairDefinition, bool, bool, bool) -> None
 
+        self.profile = defn.profile
         self.access_key_id = defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
-        if not self.access_key_id:
-            raise Exception("please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID")
 
         # Generate the key pair locally.
         if not self.public_key:
-            (private, public) = nixops.util.create_key_pair(type="rsa") # EC2 only supports RSA keys.
+            private, public = nixops.util.create_key_pair(type="rsa")  # EC2 only supports RSA keys.
             with self.depl._db:
                 self.public_key = public
                 self.private_key = private
 
         # Upload the public key to EC2.
         if check or self.state != self.UP:
-
             self.region = defn.region
-            self.connect()
 
-            # Sometimes EC2 DescribeKeypairs return empty list on invalid
-            # identifiers, which results in a IndexError exception from within boto,
-            # work around that until we figure out what is causing this.
-            try:
-                kp = self._conn.get_key_pair(defn.keypair_name)
-            except IndexError as e:
-                kp = None
+            ec2 = self.session().client('ec2')
+            keys = ec2.describe_key_pairs(Filters=[{'Name': 'key-name', 'Values': [defn.keypair_name]}])
 
             # Don't re-upload the key if it exists and we're just checking.
-            if not kp or self.state != self.UP:
-                if kp: self._conn.delete_key_pair(defn.keypair_name)
+            if not keys['KeyPairs'] or self.state != self.UP:
+                if keys['KeyPairs']:
+                    ec2.delete_key_pair(KeyName=defn.keypair_name)
                 self.log("uploading EC2 key pair ‘{0}’...".format(defn.keypair_name))
-                self._conn.import_key_pair(defn.keypair_name, self.public_key)
+                ec2.import_key_pair(KeyName=defn.keypair_name, PublicKeyMaterial=self.public_key.encode())
 
             with self.depl._db:
                 self.state = self.UP
                 self.keypair_name = defn.keypair_name
 
-
     def destroy(self, wipe=False):
-        def keypair_used():
-            for m in self.depl.active_resources.itervalues():
-                if isinstance(m, nixopsaws.backends.ec2.EC2State) and m.key_pair == self.keypair_name:
-                    return m
-            return None
-
-        m = keypair_used()
-        if m:
-            raise Exception("keypair ‘{0}’ is still in use by ‘{1}’ ({2})".format(self.keypair_name, m.name, m.vm_id))
+        for m in self.depl.active_resources.values():
+            if isinstance(m, nixopsaws.backends.ec2.EC2State) and m.key_pair == self.keypair_name:
+                raise Exception("keypair ‘{0}’ is still in use by ‘{1}’ ({2})".format(self.keypair_name, m.name, m.vm_id))
 
         if not self.depl.logger.confirm("are you sure you want to destroy keypair ‘{0}’?".format(self.keypair_name)):
             return False
 
         if self.state == self.UP:
             self.log("deleting EC2 key pair ‘{0}’...".format(self.keypair_name))
-            self.connect()
-            self._conn.delete_key_pair(self.keypair_name)
+            ec2 = self.session().client('ec2')
+            ec2.delete_key_pair(KeyName=self.keypair_name)
 
         return True
 
     def check(self):
-        self.connect()
-        try:
-            kp = self._conn.get_key_pair(self.keypair_name)
-        except IndexError as e:
-            kp = None
-        if kp is None:
+        ec2 = self.session().client('ec2')
+
+        keys = ec2.describe_key_pairs(Filters=[{'Name': 'key-name', 'Values': [self.keypair_name]}])
+        if not keys['KeyPairs']:
             self.state = self.MISSING

--- a/nixopsaws/resources/elastic_file_system.py
+++ b/nixopsaws/resources/elastic_file_system.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+
 # AWS Elastic File Systems.
 
 import uuid
@@ -8,8 +10,8 @@ import botocore
 import nixops.util
 import nixopsaws.ec2_utils
 import nixops.resources
-import ec2_common
-import efs_common
+from . import ec2_common
+from . import efs_common
 import time
 
 class ElasticFileSystemDefinition(nixops.resources.ResourceDefinition):
@@ -26,9 +28,9 @@ class ElasticFileSystemDefinition(nixops.resources.ResourceDefinition):
     def show_type(self):
         return "{0} [{1}]".format(self.get_type(), self.region)
 
-class ElasticFileSystemState(nixops.resources.ResourceState, \
-                             ec2_common.EC2CommonState, \
-                             efs_common.EFSCommonState):
+class ElasticFileSystemState(ec2_common.EC2CommonState,
+                             efs_common.EFSCommonState,
+                             nixops.resources.ResourceState):
     """State of an AWS Elastic File System."""
 
     state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)

--- a/nixopsaws/resources/elastic_file_system.py
+++ b/nixopsaws/resources/elastic_file_system.py
@@ -2,17 +2,19 @@
 
 from __future__ import absolute_import
 
+import time
+import uuid
+
+import botocore.exceptions
+import nixops.resources
+import nixops.util
+
+import nixopsaws.ec2_utils
+from . import ec2_common, efs_common
+
+
 # AWS Elastic File Systems.
 
-import uuid
-import boto3
-import botocore
-import nixops.util
-import nixopsaws.ec2_utils
-import nixops.resources
-from . import ec2_common
-from . import efs_common
-import time
 
 class ElasticFileSystemDefinition(nixops.resources.ResourceDefinition):
     """Definition of an AWS Elastic File System."""
@@ -27,6 +29,7 @@ class ElasticFileSystemDefinition(nixops.resources.ResourceDefinition):
 
     def show_type(self):
         return "{0} [{1}]".format(self.get_type(), self.region)
+
 
 class ElasticFileSystemState(ec2_common.EC2CommonState,
                              efs_common.EFSCommonState,


### PR DESCRIPTION
The way how my AWS accounts are setup (assumeRole + MFA) makes it impossible to use old version of nixops. I initially tried to add an option to specify a profile, but turns out that old boto doesn't seem to support this kind of setup (since it was introduced later on) and it mandated porting to boto3.

So this version works fine with assumeRole + MFA and I also added an option to use the same cache that `aws` command uses. That way you don't have to enter MFA every for every single command.

Currently all of the commands that I used appear to be working, these are:
- list
- create
- modify
- delete
- info
- check
- deploy
- send-keys
- destroy
- stop
- start
- reboot
- show-arguments
- show-physical
- ssh
- ssh-for-each
- scp
- mount
- rename
- backup
- backup-status
- clean-backups
- restore (you need to provide backup id, but it looks like that was unrelated to my change?).
- show-option
- list-generations
- show-console-output
- dump-nix-paths
- export
- edit

If you can, please test it (clone my branch and run `nix-env -f release.nix -iA build.<your platform>`) if there are still broken commands let me know otherwise perhaps this can be merged.