### PR TITLE
Displaying EBS size in nixops-info

### DIFF
--- a/nixopsaws/resources/ebs_volume.py
+++ b/nixopsaws/resources/ebs_volume.py
@@ -56,7 +56,7 @@ class EBSVolumeState(nixops.resources.ResourceState, ec2_common.EC2CommonState):
 
     def show_type(self):
         s = super(EBSVolumeState, self).show_type()
-        if self._exists(): s = "{0} [{1}]".format(s, self.zone)
+        if self._exists(): s = "{0} [{1}; {2} GiB]".format(s, self.zone, self.size)
         return s
 
 


### PR DESCRIPTION
A simple helpful change to reflect the EBS volume size in the output of nixops info

```
| batch_data |        Up       | ebs-volume [us-east-1a; 300 GiB] | vol-0a51ecdf22ca88edf                               |                |
| test_data  |        Up       | ebs-volume [us-east-1a; 250 GiB] | vol-014a609b8f5d08058                               |                |
| host_data   |        Up       | ebs-volume [us-east-1a; 300 GiB] | vol-0f983112e8c6a00e6                               |                |
| stage_data |        Up       | ebs-volume [us-east-1a; 200 GiB] | vol-08f7ffa4d582c2021                               |                |

```
