### PR TITLE
Cleanup release.nix and setup.py; bump to 19.09 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: nix
 before_script:
   - sudo mkdir /etc/nix && echo 'sandbox = true' | sudo tee /etc/nix/nix.conf
 script:
-  - nix-build --quiet release.nix -A build.x86_64-linux -I nixpkgs=channel:nixos-19.03
+  - nix-build --quiet release.nix -A build.x86_64-linux -I nixpkgs=channel:nixos-19.09

--- a/release.nix
+++ b/release.nix
@@ -16,25 +16,18 @@ rec {
     with import nixpkgs { inherit system; };
 
     python2Packages.buildPythonApplication rec {
-      name = "nixops-aws-${version}";
+      pname = "nixops-aws";
+      inherit version;
       namePrefix = "";
 
       src = ./.;
 
       prePatch = ''
-        for i in setup.py; do
-          substituteInPlace $i --subst-var-by version ${version}
-        done
+        substituteAllInPlace setup.py
       '';
 
-      buildInputs = [ python2Packages.nose python2Packages.coverage ];
-
-
-      propagatedBuildInputs = with python2Packages;
-        [
-          boto
-          boto3
-        ];
+      buildInputs = with python2Packages; [ nose coverage ];
+      propagatedBuildInputs = with python2Packages; [ boto boto3 ];
 
       # For "nix-build --run-env".
       shellHook = ''
@@ -51,13 +44,12 @@ rec {
       # the version of openssh is causing errors when have big networks (40+)
       makeWrapperArgs = ["--prefix" "PATH" ":" "${openssh}/bin" "--set" "PYTHONPATH" ":"];
 
-      postInstall =
-        ''
-          mkdir -p $out/share/nix/nixops-aws
-          cp -av nix/* $out/share/nix/nixops-aws
-        '';
+      postInstall = ''
+        mkdir -p $out/share/nix/nixops-aws
+        cp -av nix/* $out/share/nix/nixops-aws
+      '';
 
-      meta.description = "Nix package for ${stdenv.system}";
+      meta.description = "NixOps AWS package for ${stdenv.system}";
     }
   );
 }

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,4 @@
-import sys
-import subprocess
-
-from distutils.core import setup, Command
+from distutils.core import setup
 
 
 setup(name='nixops-aws',


### PR DESCRIPTION
- Use pname
- Consistent formatting and indentation
- Better meta description
- Use substituteAllInPlace
- Cleanup setup.py
- Use 19.09 channel in Travis CI

No real functional change.