### PR TITLE
Format python code with Black 19.10b0

### DIFF
--- a/coverage-tests.py
+++ b/coverage-tests.py
@@ -4,8 +4,19 @@ import sys
 import os
 
 if __name__ == "__main__":
-    nose.main(argv=[sys.argv[0], "--with-coverage",
-                    "--cover-inclusive", "--cover-xml",
-                    "--cover-xml-file=coverage.xml", "--cover-html",
-                    "--cover-html-dir=./html", "--cover-package=nixops","--nocapture",
-                    "-e", "^tests\.py$"] + sys.argv[1:])
+    nose.main(
+        argv=[
+            sys.argv[0],
+            "--with-coverage",
+            "--cover-inclusive",
+            "--cover-xml",
+            "--cover-xml-file=coverage.xml",
+            "--cover-html",
+            "--cover-html-dir=./html",
+            "--cover-package=nixops",
+            "--nocapture",
+            "-e",
+            "^tests\.py$",
+        ]
+        + sys.argv[1:]
+    )

--- a/nix/generate-ec2-properties.py
+++ b/nix/generate-ec2-properties.py
@@ -1,30 +1,47 @@
 #! /usr/bin/env python2
 import json
 from pprint import pprint
-#FIXME: AWS support adviced against the use of this index file for anything other than pricing
+
+# FIXME: AWS support adviced against the use of this index file for anything other than pricing
 # This file also do not provide a way to confidently check if an instance use nvme or not
 # and there is currently no API that can provide such information. So manuall fixes is needed
 # after running this script.
 # A feature request is in place to provide an endpoint that can cover our need.
 # curl -O https://pricing.us-east-1.amazonaws.com/offers/v1.0/aws/AmazonEC2/current/index.json
-with open('index.json') as f:
+with open("index.json") as f:
     data = json.load(f)
 
 instanceTypes = {}
-for p in data['products'].keys():
-    product = data['products'][p]['attributes']
-    if 'operatingSystem' in product and product['operatingSystem'] in ('NA', 'Linux') \
-       and 'tenancy' in product and product['tenancy'] == 'Shared' \
-       and product['location'] == 'US East (N. Virginia)':
-           ebsOptimized = 'ebsOptimized' in product
-           instanceType = product['instanceType']
-           cores = product['vcpu']
-           memory = int(float(product['memory'].replace(',','').split(' ')[0]) * 1024)
-           if instanceType in instanceTypes and not ebsOptimized:
-               continue
-           instanceTypes[product['instanceType']] = '  "'+instanceType+'" = { cores = '+cores+'; memory = '+str(memory)+'; allowsEbsOptimized = '+('true' if ebsOptimized else 'false')+'; supportsNVMe = '+'false'+';};'
+for p in data["products"].keys():
+    product = data["products"][p]["attributes"]
+    if (
+        "operatingSystem" in product
+        and product["operatingSystem"] in ("NA", "Linux")
+        and "tenancy" in product
+        and product["tenancy"] == "Shared"
+        and product["location"] == "US East (N. Virginia)"
+    ):
+        ebsOptimized = "ebsOptimized" in product
+        instanceType = product["instanceType"]
+        cores = product["vcpu"]
+        memory = int(float(product["memory"].replace(",", "").split(" ")[0]) * 1024)
+        if instanceType in instanceTypes and not ebsOptimized:
+            continue
+        instanceTypes[product["instanceType"]] = (
+            '  "'
+            + instanceType
+            + '" = { cores = '
+            + cores
+            + "; memory = "
+            + str(memory)
+            + "; allowsEbsOptimized = "
+            + ("true" if ebsOptimized else "false")
+            + "; supportsNVMe = "
+            + "false"
+            + ";};"
+        )
 
-print '{'
+print "{"
 for instanceType in sorted(instanceTypes.keys()):
     print instanceTypes[instanceType]
-print '}'
+print "}"

--- a/nixopsaws/backends/ec2.py
+++ b/nixopsaws/backends/ec2.py
@@ -16,21 +16,28 @@ from nixopsaws.resources.ebs_volume import EBSVolumeState
 from nixopsaws.resources.elastic_ip import ElasticIPState
 import nixopsaws.resources.ec2_common
 import nixopsaws.resources
-from nixops.util import device_name_to_boto_expected, device_name_stored_to_real, device_name_user_entered_to_stored
+from nixops.util import (
+    device_name_to_boto_expected,
+    device_name_stored_to_real,
+    device_name_user_entered_to_stored,
+)
 import nixopsaws.ec2_utils
 import nixops.known_hosts
 from xml import etree
 import datetime
 import boto3
 
+
 class EC2InstanceDisappeared(Exception):
     pass
+
 
 # name conventions:
 # device - device name that user enters: sd, xvd or nvme
 # device_stored - device name stored in db: sd or nvme
 # device_real - device name attached to machine: xvd or nvme, sd can't be attached
 # device_that_boto_expects - only sd device names can be passed to boto, but amazon will attach them as xvd or nvme based on machine type
+
 
 class EC2Definition(MachineDefinition):
     """Definition of an EC2 machine."""
@@ -60,7 +67,9 @@ class EC2Definition(MachineDefinition):
         self.spot_instance_price = config["ec2"]["spotInstancePrice"]
         self.spot_instance_timeout = config["ec2"]["spotInstanceTimeout"]
         self.spot_instance_request_type = config["ec2"]["spotInstanceRequestType"]
-        self.spot_instance_interruption_behavior = config["ec2"]["spotInstanceInterruptionBehavior"]
+        self.spot_instance_interruption_behavior = config["ec2"][
+            "spotInstanceInterruptionBehavior"
+        ]
         self.ebs_optimized = config["ec2"]["ebsOptimized"]
         self.subnet_id = config["ec2"]["subnetId"]
         self.associate_public_ip_address = config["ec2"]["associatePublicIpAddress"]
@@ -69,7 +78,10 @@ class EC2Definition(MachineDefinition):
         self.security_group_ids = config["ec2"]["securityGroupIds"]
 
         # convert sd to xvd because they are equal from aws perspective
-        self.block_device_mapping = {device_name_user_entered_to_stored(k): v for k, v in config["ec2"]["blockDeviceMapping"].iteritems()}
+        self.block_device_mapping = {
+            device_name_user_entered_to_stored(k): v
+            for k, v in config["ec2"]["blockDeviceMapping"].iteritems()
+        }
 
         self.elastic_ipv4 = config["ec2"]["elasticIPv4"]
 
@@ -83,7 +95,12 @@ class EC2Definition(MachineDefinition):
         return "{0} [{1}]".format(self.get_type(), self.region or self.zone or "???")
 
     def host_key_type(self):
-        return "ed25519" if nixops.util.parse_nixos_version(self.config["nixosRelease"]) >= ["15", "09"] else "dsa"
+        return (
+            "ed25519"
+            if nixops.util.parse_nixos_version(self.config["nixosRelease"])
+            >= ["15", "09"]
+            else "dsa"
+        )
 
 
 class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
@@ -100,9 +117,15 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
     public_ipv4 = nixops.util.attr_property("publicIpv4", None)
     private_ipv4 = nixops.util.attr_property("privateIpv4", None)
     public_dns_name = nixops.util.attr_property("publicDnsName", None)
-    use_private_ip_address = nixops.util.attr_property("ec2.usePrivateIpAddress", False, type=bool)
-    source_dest_check = nixops.util.attr_property("ec2.sourceDestCheck", True, type=bool)
-    associate_public_ip_address = nixops.util.attr_property("ec2.associatePublicIpAddress", False, type=bool)
+    use_private_ip_address = nixops.util.attr_property(
+        "ec2.usePrivateIpAddress", False, type=bool
+    )
+    source_dest_check = nixops.util.attr_property(
+        "ec2.sourceDestCheck", True, type=bool
+    )
+    associate_public_ip_address = nixops.util.attr_property(
+        "ec2.associatePublicIpAddress", False, type=bool
+    )
     elastic_ipv4 = nixops.util.attr_property("ec2.elasticIpv4", None)
     access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
     region = nixops.util.attr_property("ec2.region", None)
@@ -116,16 +139,20 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
     private_host_key = nixops.util.attr_property("ec2.privateHostKey", None)
     private_key_file = nixops.util.attr_property("ec2.privateKeyFile", None)
     instance_profile = nixops.util.attr_property("ec2.instanceProfile", None)
-    security_groups = nixops.util.attr_property("ec2.securityGroups", None, 'json')
-    placement_group = nixops.util.attr_property("ec2.placementGroup", None, 'json')
-    block_device_mapping = nixops.util.attr_property("ec2.blockDeviceMapping", {}, 'json')
+    security_groups = nixops.util.attr_property("ec2.securityGroups", None, "json")
+    placement_group = nixops.util.attr_property("ec2.placementGroup", None, "json")
+    block_device_mapping = nixops.util.attr_property(
+        "ec2.blockDeviceMapping", {}, "json"
+    )
     root_device_type = nixops.util.attr_property("ec2.rootDeviceType", None)
-    backups = nixops.util.attr_property("ec2.backups", {}, 'json')
+    backups = nixops.util.attr_property("ec2.backups", {}, "json")
     dns_hostname = nixops.util.attr_property("route53.hostName", None)
     dns_ttl = nixops.util.attr_property("route53.ttl", None, int)
     route53_access_key_id = nixops.util.attr_property("route53.accessKeyId", None)
     client_token = nixops.util.attr_property("ec2.clientToken", None)
-    spot_instance_request_id = nixops.util.attr_property("ec2.spotInstanceRequestId", None)
+    spot_instance_request_id = nixops.util.attr_property(
+        "ec2.spotInstanceRequestId", None
+    )
     spot_instance_price = nixops.util.attr_property("ec2.spotInstancePrice", None)
     subnet_id = nixops.util.attr_property("ec2.subnetId", None)
     first_boot = nixops.util.attr_property("ec2.firstBoot", True, type=bool)
@@ -138,7 +165,6 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         self._conn_route53 = None
         self._conn_boto3 = None
         self._cached_instance = None
-
 
     def _reset_state(self):
         """Discard all state pertaining to an instance."""
@@ -180,25 +206,35 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         retVal = None
         if self.use_private_ip_address:
             if not self.private_ipv4:
-                raise Exception("EC2 machine '{0}' does not have a private IPv4 address (yet)".format(self.name))
+                raise Exception(
+                    "EC2 machine '{0}' does not have a private IPv4 address (yet)".format(
+                        self.name
+                    )
+                )
             retVal = self.private_ipv4
         else:
             if not self.public_ipv4:
-                raise Exception("EC2 machine ‘{0}’ does not have a public IPv4 address (yet)".format(self.name))
+                raise Exception(
+                    "EC2 machine ‘{0}’ does not have a public IPv4 address (yet)".format(
+                        self.name
+                    )
+                )
             retVal = self.public_ipv4
         return retVal
 
-
     def get_ssh_private_key_file(self):
-        if self.private_key_file: return self.private_key_file
-        if self._ssh_private_key_file: return self._ssh_private_key_file
+        if self.private_key_file:
+            return self.private_key_file
+        if self._ssh_private_key_file:
+            return self._ssh_private_key_file
         for r in self.depl.active_resources.itervalues():
-            if isinstance(r, nixopsaws.resources.ec2_keypair.EC2KeyPairState) and \
-                    r.state == nixopsaws.resources.ec2_keypair.EC2KeyPairState.UP and \
-                    r.keypair_name == self.key_pair:
+            if (
+                isinstance(r, nixopsaws.resources.ec2_keypair.EC2KeyPairState)
+                and r.state == nixopsaws.resources.ec2_keypair.EC2KeyPairState.UP
+                and r.keypair_name == self.key_pair
+            ):
                 return self.write_ssh_private_key(r.private_key)
         return None
-
 
     def get_ssh_flags(self, *args, **kwargs):
         file = self.get_ssh_private_key_file()
@@ -210,22 +246,26 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         for device_stored, v in self.block_device_mapping.items():
             device_real = device_name_stored_to_real(device_stored)
 
-            if (v.get('encrypt', False)
-                and v.get('encryptionType', "luks") == "luks"
-                and v.get('passphrase', "") == ""
-                and v.get('generatedKey', "") != ""):
+            if (
+                v.get("encrypt", False)
+                and v.get("encryptionType", "luks") == "luks"
+                and v.get("passphrase", "") == ""
+                and v.get("generatedKey", "") != ""
+            ):
                 block_device_mapping[device_real] = {
-                    'passphrase': Call(RawValue("pkgs.lib.mkOverride 10"),
-                                           v['generatedKey']),
+                    "passphrase": Call(
+                        RawValue("pkgs.lib.mkOverride 10"), v["generatedKey"]
+                    ),
                 }
 
         return {
-            'imports': [
+            "imports": [
                 RawValue("<nixpkgs/nixos/modules/virtualisation/amazon-image.nix>")
             ],
-            ('deployment', 'ec2', 'blockDeviceMapping'): block_device_mapping,
-            ('deployment', 'ec2', 'instanceId'): self.vm_id,
-            ('ec2', 'hvm'): self.virtualization_type == "hvm" or self.virtualization_type is None,
+            ("deployment", "ec2", "blockDeviceMapping"): block_device_mapping,
+            ("deployment", "ec2", "instanceId"): self.vm_id,
+            ("ec2", "hvm"): self.virtualization_type == "hvm"
+            or self.virtualization_type is None,
         }
 
     def get_physical_backup_spec(self, backupid):
@@ -234,15 +274,18 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             for device_stored, snap in self.backups[backupid].items():
                 device_real = device_name_stored_to_real(device_stored)
 
-                is_root_device = device_real.startswith("/dev/xvda") or device_real.startswith("/dev/nvme0")
+                is_root_device = device_real.startswith(
+                    "/dev/xvda"
+                ) or device_real.startswith("/dev/nvme0")
 
                 if not is_root_device:
-                    val[device_real] = { 'disk': Call(RawValue("pkgs.lib.mkOverride 10"), snap)}
-            val = { ('deployment', 'ec2', 'blockDeviceMapping'): val }
+                    val[device_real] = {
+                        "disk": Call(RawValue("pkgs.lib.mkOverride 10"), snap)
+                    }
+            val = {("deployment", "ec2", "blockDeviceMapping"): val}
         else:
             val = RawValue("{{}} /* No backup found for id '{0}' */".format(backupid))
         return Function("{ config, pkgs, ... }", val)
-
 
     def get_keys(self):
         keys = MachineState.get_keys(self)
@@ -251,45 +294,60 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         # the final nix-build). Had to hardcode the default here to
         # make the old way of defining keys work.
         for device_stored, v in self.block_device_mapping.items():
-            if v.get('encrypt', False) and v.get('passphrase', "") == "" and v.get('generatedKey', "") != "" and v.get('encryptionType', "luks") == "luks":
+            if (
+                v.get("encrypt", False)
+                and v.get("passphrase", "") == ""
+                and v.get("generatedKey", "") != ""
+                and v.get("encryptionType", "luks") == "luks"
+            ):
                 device_real = device_name_stored_to_real(device_stored)
 
-                key_name = "luks-" + device_real.replace('/dev/', '')
-                keys[key_name] = { 'text': v['generatedKey'], 'keyFile': '/run/keys/' + key_name, 'destDir': '/run/keys', 'group': 'root', 'permissions': '0600', 'user': 'root'}
+                key_name = "luks-" + device_real.replace("/dev/", "")
+                keys[key_name] = {
+                    "text": v["generatedKey"],
+                    "keyFile": "/run/keys/" + key_name,
+                    "destDir": "/run/keys",
+                    "group": "root",
+                    "permissions": "0600",
+                    "user": "root",
+                }
         return keys
-
 
     def show_type(self):
         s = super(EC2State, self).show_type()
-        if self.zone or self.region: s = "{0} [{1}; {2}]".format(s, self.zone or self.region, self.instance_type)
+        if self.zone or self.region:
+            s = "{0} [{1}; {2}]".format(s, self.zone or self.region, self.instance_type)
         return s
-
 
     @property
     def resource_id(self):
         return self.vm_id
 
-
     def address_to(self, m):
-        if isinstance(m, EC2State): # FIXME: only if we're in the same region
+        if isinstance(m, EC2State):  # FIXME: only if we're in the same region
             return m.private_ipv4
         return MachineState.address_to(self, m)
 
-
     def connect(self):
-        if self._conn: return self._conn
+        if self._conn:
+            return self._conn
         self._conn = nixopsaws.ec2_utils.connect(self.region, self.access_key_id)
         return self._conn
 
     def connect_boto3(self):
-        if self._conn_boto3: return self._conn_boto3
-        self._conn_boto3 = nixopsaws.ec2_utils.connect_ec2_boto3(self.region, self.access_key_id)
+        if self._conn_boto3:
+            return self._conn_boto3
+        self._conn_boto3 = nixopsaws.ec2_utils.connect_ec2_boto3(
+            self.region, self.access_key_id
+        )
         return self._conn_boto3
 
     def connect_vpc(self):
         if self._conn_vpc:
             return self._conn_vpc
-        self._conn_vpc = nixopsaws.ec2_utils.connect_vpc(self.region, self.access_key_id)
+        self._conn_vpc = nixopsaws.ec2_utils.connect_vpc(
+            self.region, self.access_key_id
+        )
         return self._conn_vpc
 
     def connect_route53(self):
@@ -297,10 +355,11 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             return
 
         # Get the secret access key from the environment or from ~/.ec2-keys.
-        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(self.route53_access_key_id)
+        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(
+            self.route53_access_key_id
+        )
 
         self._conn_route53 = boto.connect_route53(access_key_id, secret_access_key)
-
 
     def _get_spot_instance_request_by_id(self, request_id, allow_missing=False):
         """Get spot instance request object by id."""
@@ -308,20 +367,25 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         try:
             result = self._conn.get_all_spot_instance_requests([request_id])
         except boto.exception.EC2ResponseError as e:
-            if allow_missing and e.error_code == "InvalidSpotInstanceRequestID.NotFound":
+            if (
+                allow_missing
+                and e.error_code == "InvalidSpotInstanceRequestID.NotFound"
+            ):
                 result = []
             else:
                 raise
         if len(result) == 0:
             if allow_missing:
                 return None
-            raise EC2InstanceDisappeared("Spot instance request ‘{0}’ disappeared!".format(request_id))
+            raise EC2InstanceDisappeared(
+                "Spot instance request ‘{0}’ disappeared!".format(request_id)
+            )
         return result[0]
-
 
     def _get_instance(self, instance_id=None, allow_missing=False, update=False):
         """Get instance object for this machine, with caching"""
-        if not instance_id: instance_id = self.vm_id
+        if not instance_id:
+            instance_id = self.vm_id
         assert instance_id
 
         if not self._cached_instance:
@@ -336,17 +400,22 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             if len(instances) == 0:
                 if allow_missing:
                     return None
-                raise EC2InstanceDisappeared("EC2 instance ‘{0}’ disappeared!".format(instance_id))
+                raise EC2InstanceDisappeared(
+                    "EC2 instance ‘{0}’ disappeared!".format(instance_id)
+                )
             self._cached_instance = instances[0]
 
         elif update:
             self._cached_instance.update()
 
         if self._cached_instance.launch_time:
-            self.start_time = calendar.timegm(time.strptime(self._cached_instance.launch_time, "%Y-%m-%dT%H:%M:%S.000Z"))
+            self.start_time = calendar.timegm(
+                time.strptime(
+                    self._cached_instance.launch_time, "%Y-%m-%dT%H:%M:%S.000Z"
+                )
+            )
 
         return self._cached_instance
-
 
     def _get_snapshot_by_id(self, snapshot_id):
         """Get snapshot object by instance id."""
@@ -355,8 +424,6 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         if len(snapshots) != 1:
             raise Exception("unable to find snapshot ‘{0}’".format(snapshot_id))
         return snapshots[0]
-
-
 
     def _wait_for_ip(self):
         self.log_start("waiting for IP address... ".format(self.name))
@@ -372,8 +439,18 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         while True:
             instance = self._get_instance(update=True)
             self.log_continue("[{0}] ".format(instance.state))
-            if instance.state not in {"pending", "running", "scheduling", "launching", "stopped"}:
-                raise Exception("EC2 instance ‘{0}’ failed to start (state is ‘{1}’)".format(self.vm_id, instance.state))
+            if instance.state not in {
+                "pending",
+                "running",
+                "scheduling",
+                "launching",
+                "stopped",
+            }:
+                raise Exception(
+                    "EC2 instance ‘{0}’ failed to start (state is ‘{1}’)".format(
+                        self.vm_id, instance.state
+                    )
+                )
             if instance.state != "running":
                 time.sleep(3)
                 continue
@@ -381,7 +458,9 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                 break
             time.sleep(3)
 
-        self.log_end("{0} / {1}".format(instance.ip_address, instance.private_ip_address))
+        self.log_end(
+            "{0} / {1}".format(instance.ip_address, instance.private_ip_address)
+        )
 
         with self.depl._db:
             self.private_ipv4 = instance.private_ip_address
@@ -389,7 +468,9 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             self.public_dns_name = instance.public_dns_name
             self.ssh_pinged = False
 
-        nixops.known_hosts.update(self.public_ipv4, self._ip_for_ssh_key(), self.public_host_key)
+        nixops.known_hosts.update(
+            self.public_ipv4, self._ip_for_ssh_key(), self.public_host_key
+        )
 
     def _ip_for_ssh_key(self):
         if self.use_private_ip_address:
@@ -400,7 +481,6 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
     def _booted_from_ebs(self):
         return self.root_device_type == "ebs"
 
-
     def update_block_device_mapping(self, k, v):
         x = self.block_device_mapping
         if v == None:
@@ -409,12 +489,14 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             x[k] = v
         self.block_device_mapping = x
 
-
     def get_backups(self):
-        if not self.region: return {}
+        if not self.region:
+            return {}
         self.connect()
         backups = {}
-        current_volumes = set([v['volumeId'] for v in self.block_device_mapping.values()])
+        current_volumes = set(
+            [v["volumeId"] for v in self.block_device_mapping.values()]
+        )
         for b_id, b in self.backups.items():
             b = {device_name_stored_to_real(device): snap for device, snap in b.items()}
             backups[b_id] = {}
@@ -428,24 +510,32 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                     try:
                         snapshot = self._get_snapshot_by_id(snapshot_id)
                         snapshot_status = snapshot.update()
-                        info.append("progress[{0},{1},{2}] = {3}".format(self.name, device_real, snapshot_id, snapshot_status))
-                        if snapshot_status != '100%':
+                        info.append(
+                            "progress[{0},{1},{2}] = {3}".format(
+                                self.name, device_real, snapshot_id, snapshot_status
+                            )
+                        )
+                        if snapshot_status != "100%":
                             backup_status = "running"
                     except boto.exception.EC2ResponseError as e:
-                        if e.error_code != "InvalidSnapshot.NotFound": raise
-                        info.append("{0} - {1} - {2} - Snapshot has disappeared".format(self.name, device_real, snapshot_id))
+                        if e.error_code != "InvalidSnapshot.NotFound":
+                            raise
+                        info.append(
+                            "{0} - {1} - {2} - Snapshot has disappeared".format(
+                                self.name, device_real, snapshot_id
+                            )
+                        )
                         backup_status = "unavailable"
-            backups[b_id]['status'] = backup_status
-            backups[b_id]['info'] = info
+            backups[b_id]["status"] = backup_status
+            backups[b_id]["info"] = info
         return backups
 
-
     def remove_backup(self, backup_id, keep_physical=False):
-        self.log('removing backup {0}'.format(backup_id))
+        self.log("removing backup {0}".format(backup_id))
         self.connect()
         _backups = self.backups
         if not backup_id in _backups.keys():
-            self.warn('backup {0} not found, skipping'.format(backup_id))
+            self.warn("backup {0} not found, skipping".format(backup_id))
         else:
             if not keep_physical:
                 for dev, snapshot_id in _backups[backup_id].items():
@@ -453,14 +543,15 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                     try:
                         snapshot = self._get_snapshot_by_id(snapshot_id)
                     except:
-                        self.warn('snapshot {0} not found, skipping'.format(snapshot_id))
+                        self.warn(
+                            "snapshot {0} not found, skipping".format(snapshot_id)
+                        )
                     if not snapshot is None:
-                        self.log('removing snapshot {0}'.format(snapshot_id))
+                        self.log("removing snapshot {0}".format(snapshot_id))
                         self._retry(lambda: snapshot.delete())
 
             _backups.pop(backup_id)
             self.backups = _backups
-
 
     def backup(self, defn, backup_id, devices=[]):
         self.connect()
@@ -473,15 +564,25 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             device_real = device_name_stored_to_real(device_stored)
 
             if devices == [] or device_real in devices:
-                snapshot = self._retry(lambda: self._conn.create_snapshot(volume_id=v['volumeId']))
-                self.log("+ created snapshot of volume ‘{0}’: ‘{1}’".format(v['volumeId'], snapshot.id))
+                snapshot = self._retry(
+                    lambda: self._conn.create_snapshot(volume_id=v["volumeId"])
+                )
+                self.log(
+                    "+ created snapshot of volume ‘{0}’: ‘{1}’".format(
+                        v["volumeId"], snapshot.id
+                    )
+                )
 
                 snapshot_tags = {}
                 snapshot_tags.update(defn.tags)
                 snapshot_tags.update(self.get_common_tags())
-                snapshot_tags['Name'] = "{0} - {3} [{1} - {2}]".format(self.depl.name, self.name, device_stored, backup_id)
+                snapshot_tags["Name"] = "{0} - {3} [{1} - {2}]".format(
+                    self.depl.name, self.name, device_stored, backup_id
+                )
 
-                self._retry(lambda: self._conn.create_tags([snapshot.id], snapshot_tags))
+                self._retry(
+                    lambda: self._conn.create_tags([snapshot.id], snapshot_tags)
+                )
                 backup[device_stored] = snapshot.id
 
         _backups[backup_id] = backup
@@ -500,7 +601,9 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
             if devices == [] or device_real in devices:
                 # detach disks
-                volume = nixopsaws.ec2_utils.get_volume_by_id(self.connect(), v['volumeId'])
+                volume = nixopsaws.ec2_utils.get_volume_by_id(
+                    self.connect(), v["volumeId"]
+                )
                 if volume and volume.update() == "in-use":
                     self.log("detaching volume from ‘{0}’".format(self.name))
                     volume.detach()
@@ -511,83 +614,134 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
                 self.wait_for_snapshot_to_become_completed(snapshot_id)
 
-                new_volume = self._conn.create_volume(size=0, snapshot=snapshot_id, zone=self.zone)
+                new_volume = self._conn.create_volume(
+                    size=0, snapshot=snapshot_id, zone=self.zone
+                )
 
                 # Check if original volume is available, aka detached from the machine.
                 if volume:
-                    nixopsaws.ec2_utils.wait_for_volume_available(self._conn, volume.id, self.logger)
+                    nixopsaws.ec2_utils.wait_for_volume_available(
+                        self._conn, volume.id, self.logger
+                    )
 
                 # Check if new volume is available.
-                nixopsaws.ec2_utils.wait_for_volume_available(self._conn, new_volume.id, self.logger)
+                nixopsaws.ec2_utils.wait_for_volume_available(
+                    self._conn, new_volume.id, self.logger
+                )
 
-                self.log("attaching volume ‘{0}’ to ‘{1}’ as {2}".format(new_volume.id, self.name, device_real))
+                self.log(
+                    "attaching volume ‘{0}’ to ‘{1}’ as {2}".format(
+                        new_volume.id, self.name, device_real
+                    )
+                )
 
-                device_that_boto_expects = device_name_to_boto_expected(device_real) # boto expects only sd names
+                device_that_boto_expects = device_name_to_boto_expected(
+                    device_real
+                )  # boto expects only sd names
                 new_volume.attach(self.vm_id, device_that_boto_expects)
 
                 new_v = self.block_device_mapping[device_stored]
 
-                if v.get('partOfImage', False) or v.get('charonDeleteOnTermination', False) or v.get('deleteOnTermination', False):
-                    new_v['charonDeleteOnTermination'] = True
-                    self._delete_volume(v['volumeId'], True)
-                new_v['volumeId'] = new_volume.id
+                if (
+                    v.get("partOfImage", False)
+                    or v.get("charonDeleteOnTermination", False)
+                    or v.get("deleteOnTermination", False)
+                ):
+                    new_v["charonDeleteOnTermination"] = True
+                    self._delete_volume(v["volumeId"], True)
+                new_v["volumeId"] = new_volume.id
                 self.update_block_device_mapping(device_stored, new_v)
 
     def wait_for_snapshot_to_become_completed(self, snapshot_id):
         def check_completed():
             res = self._get_snapshot_by_id(snapshot_id).status
             self.log_continue("[{0}] ".format(res))
-            return res == 'completed'
+            return res == "completed"
 
-        self.log_start("waiting for snapshot ‘{0}’ to have status ‘completed’... ".format(snapshot_id))
+        self.log_start(
+            "waiting for snapshot ‘{0}’ to have status ‘completed’... ".format(
+                snapshot_id
+            )
+        )
         nixops.util.check_wait(check_completed)
-        self.log_end('')
+        self.log_end("")
 
     def create_after(self, resources, defn):
         # EC2 instances can require key pairs, IAM roles, security
         # groups, EBS volumes and elastic IPs.  FIXME: only depend on
         # the specific key pair / role needed for this instance.
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.ec2_keypair.EC2KeyPairState) or
-                isinstance(r, nixopsaws.resources.iam_role.IAMRoleState) or
-                isinstance(r, nixopsaws.resources.ec2_security_group.EC2SecurityGroupState) or
-                isinstance(r, nixopsaws.resources.ec2_placement_group.EC2PlacementGroupState) or
-                isinstance(r, nixopsaws.resources.ebs_volume.EBSVolumeState) or
-                isinstance(r, nixopsaws.resources.elastic_ip.ElasticIPState) or
-                isinstance(r, nixopsaws.resources.vpc_subnet.VPCSubnetState) or
-                isinstance(r, nixopsaws.resources.vpc_route.VPCRouteState) or
-                isinstance(r, nixopsaws.resources.elastic_file_system.ElasticFileSystemState) or
-                isinstance(r, nixopsaws.resources.elastic_file_system_mount_target.ElasticFileSystemMountTargetState)}
-
+        return {
+            r
+            for r in resources
+            if isinstance(r, nixopsaws.resources.ec2_keypair.EC2KeyPairState)
+            or isinstance(r, nixopsaws.resources.iam_role.IAMRoleState)
+            or isinstance(
+                r, nixopsaws.resources.ec2_security_group.EC2SecurityGroupState
+            )
+            or isinstance(
+                r, nixopsaws.resources.ec2_placement_group.EC2PlacementGroupState
+            )
+            or isinstance(r, nixopsaws.resources.ebs_volume.EBSVolumeState)
+            or isinstance(r, nixopsaws.resources.elastic_ip.ElasticIPState)
+            or isinstance(r, nixopsaws.resources.vpc_subnet.VPCSubnetState)
+            or isinstance(r, nixopsaws.resources.vpc_route.VPCRouteState)
+            or isinstance(
+                r, nixopsaws.resources.elastic_file_system.ElasticFileSystemState
+            )
+            or isinstance(
+                r,
+                nixopsaws.resources.elastic_file_system_mount_target.ElasticFileSystemMountTargetState,
+            )
+        }
 
     def attach_volume(self, device_stored, volume_id):
         device_real = device_name_stored_to_real(device_stored)
 
         volume = nixopsaws.ec2_utils.get_volume_by_id(self.connect(), volume_id)
         if not volume:
-            raise Exception("volume {0} doesn't exist, run check to update the state of the volume".format(volume_id))
-        if volume.status == "in-use" and \
-            self.vm_id != volume.attach_data.instance_id and \
-            self.depl.logger.confirm("volume ‘{0}’ is in use by instance ‘{1}’, "
-                                     "are you sure you want to attach this volume?".format(volume_id, volume.attach_data.instance_id)):
+            raise Exception(
+                "volume {0} doesn't exist, run check to update the state of the volume".format(
+                    volume_id
+                )
+            )
+        if (
+            volume.status == "in-use"
+            and self.vm_id != volume.attach_data.instance_id
+            and self.depl.logger.confirm(
+                "volume ‘{0}’ is in use by instance ‘{1}’, "
+                "are you sure you want to attach this volume?".format(
+                    volume_id, volume.attach_data.instance_id
+                )
+            )
+        ):
 
-            self.log_start("detaching volume ‘{0}’ from instance ‘{1}’... ".format(volume_id, volume.attach_data.instance_id))
+            self.log_start(
+                "detaching volume ‘{0}’ from instance ‘{1}’... ".format(
+                    volume_id, volume.attach_data.instance_id
+                )
+            )
             volume.detach()
 
             def check_available():
                 res = volume.update()
                 self.log_continue("[{0}] ".format(res))
-                return res == 'available'
+                return res == "available"
 
             nixops.util.check_wait(check_available)
-            self.log_end('')
+            self.log_end("")
 
             if volume.update() != "available":
-                self.log("force detaching volume ‘{0}’ from instance ‘{1}’...".format(volume_id, volume.attach_data.instance_id))
+                self.log(
+                    "force detaching volume ‘{0}’ from instance ‘{1}’...".format(
+                        volume_id, volume.attach_data.instance_id
+                    )
+                )
                 volume.detach(True)
                 nixops.util.check_wait(check_available)
 
-        self.log_start("attaching volume ‘{0}’ as ‘{1}’... ".format(volume_id, device_real))
+        self.log_start(
+            "attaching volume ‘{0}’ as ‘{1}’... ".format(volume_id, device_real)
+        )
 
         if self.vm_id != volume.attach_data.instance_id:
             # Attach it.
@@ -598,7 +752,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             volume.update()
             res = volume.attach_data.status
             self.log_continue("[{0}] ".format(res or "not-attached"))
-            return res == 'attached'
+            return res == "attached"
 
         # If volume is not in attached state, wait for it before going on.
         if volume.attach_data.status != "attached":
@@ -609,50 +763,68 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             res = self.run_command("test -e {0}".format(device_real), check=False)
             return res == 0
 
-        if not nixops.util.check_wait(check_device, initial=1, max_tries=10, exception=False):
+        if not nixops.util.check_wait(
+            check_device, initial=1, max_tries=10, exception=False
+        ):
             # If stopping times out, then do an unclean shutdown.
             self.log_end("(timed out)")
 
             self.log("can't find device ‘{0}’...".format(device_real))
-            self.log('available devices:')
+            self.log("available devices:")
             self.run_command("lsblk")
 
             raise Exception("operation timed out")
         else:
-            self.log_end('')
+            self.log_end("")
 
     def _assign_elastic_ip(self, elastic_ipv4, check):
         instance = self._get_instance()
 
         # Assign or release an elastic IP address, if given.
-        if (self.elastic_ipv4 or "") != elastic_ipv4 or (instance.ip_address != elastic_ipv4) or check:
+        if (
+            (self.elastic_ipv4 or "") != elastic_ipv4
+            or (instance.ip_address != elastic_ipv4)
+            or check
+        ):
             if elastic_ipv4 != "":
                 # wait until machine is in running state
-                self.log_start("waiting for machine to be in running state... ".format(self.name))
+                self.log_start(
+                    "waiting for machine to be in running state... ".format(self.name)
+                )
                 while True:
                     self.log_continue("[{0}] ".format(instance.state))
                     if instance.state == "running":
                         break
                     if instance.state not in {"running", "pending"}:
                         raise Exception(
-                            "EC2 instance ‘{0}’ failed to reach running state (state is ‘{1}’)"
-                            .format(self.vm_id, instance.state))
+                            "EC2 instance ‘{0}’ failed to reach running state (state is ‘{1}’)".format(
+                                self.vm_id, instance.state
+                            )
+                        )
                     time.sleep(3)
                     instance = self._get_instance(update=True)
                 self.log_end("")
 
                 addresses = self._conn.get_all_addresses(addresses=[elastic_ipv4])
-                if addresses[0].instance_id != "" \
-                    and addresses[0].instance_id is not None \
-                    and addresses[0].instance_id != self.vm_id \
+                if (
+                    addresses[0].instance_id != ""
+                    and addresses[0].instance_id is not None
+                    and addresses[0].instance_id != self.vm_id
                     and not self.depl.logger.confirm(
                         "are you sure you want to associate IP address ‘{0}’, which is currently in use by instance ‘{1}’?".format(
-                            elastic_ipv4, addresses[0].instance_id)):
-                    raise Exception("elastic IP ‘{0}’ already in use...".format(elastic_ipv4))
+                            elastic_ipv4, addresses[0].instance_id
+                        )
+                    )
+                ):
+                    raise Exception(
+                        "elastic IP ‘{0}’ already in use...".format(elastic_ipv4)
+                    )
                 else:
                     self.log("associating IP address ‘{0}’...".format(elastic_ipv4))
                     addresses[0].associate(self.vm_id)
-                    self.log_start("waiting for address to be associated with this machine... ")
+                    self.log_start(
+                        "waiting for address to be associated with this machine... "
+                    )
                     instance = self._get_instance(update=True)
                     while True:
                         self.log_continue("[{0}] ".format(instance.ip_address))
@@ -662,7 +834,9 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                         instance = self._get_instance(update=True)
                     self.log_end("")
 
-                nixops.known_hosts.update(self.public_ipv4, elastic_ipv4, self.public_host_key)
+                nixops.known_hosts.update(
+                    self.public_ipv4, elastic_ipv4, self.public_host_key
+                )
 
                 with self.depl._db:
                     self.elastic_ipv4 = elastic_ipv4
@@ -672,10 +846,16 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             elif self.elastic_ipv4 != None:
                 addresses = self._conn.get_all_addresses(addresses=[self.elastic_ipv4])
                 if len(addresses) == 1 and addresses[0].instance_id == self.vm_id:
-                    self.log("disassociating IP address ‘{0}’...".format(self.elastic_ipv4))
+                    self.log(
+                        "disassociating IP address ‘{0}’...".format(self.elastic_ipv4)
+                    )
                     self._conn.disassociate_address(public_ip=self.elastic_ipv4)
                 else:
-                    self.log("address ‘{0}’ was not associated with instance ‘{1}’".format(self.elastic_ipv4, self.vm_id))
+                    self.log(
+                        "address ‘{0}’ was not associated with instance ‘{1}’".format(
+                            self.elastic_ipv4, self.vm_id
+                        )
+                    )
 
                 with self.depl._db:
                     self.elastic_ipv4 = None
@@ -683,81 +863,109 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                     self.ssh_pinged = False
 
     def security_groups_to_ids(self, subnetId, groups):
-        sg_names = filter(lambda g: not g.startswith('sg-'), groups)
-        if sg_names != [ ] and subnetId != "":
+        sg_names = filter(lambda g: not g.startswith("sg-"), groups)
+        if sg_names != [] and subnetId != "":
             self.connect_vpc()
             vpc_id = self._conn_vpc.get_all_subnets([subnetId])[0].vpc_id
-            groups = map(lambda g: nixopsaws.ec2_utils.name_to_security_group(self._conn, g, vpc_id), groups)
+            groups = map(
+                lambda g: nixopsaws.ec2_utils.name_to_security_group(
+                    self._conn, g, vpc_id
+                ),
+                groups,
+            )
 
         return groups
 
     def _wait_for_spot_request_fulfillment(self, request_id):
 
-        self.log_start("waiting for spot instance request ‘{0}’ to be fulfilled... ".format(self.spot_instance_request_id))
+        self.log_start(
+            "waiting for spot instance request ‘{0}’ to be fulfilled... ".format(
+                self.spot_instance_request_id
+            )
+        )
         while True:
-            request = self._get_spot_instance_request_by_id(self.spot_instance_request_id)
+            request = self._get_spot_instance_request_by_id(
+                self.spot_instance_request_id
+            )
             self.log_continue("[{0}] ".format(request.status.code))
-            if request.status.code == "fulfilled": break
-            if request.status.code in {"schedule-expired", "canceled-before-fulfillment", "bad-parameters", "system-error"}:
+            if request.status.code == "fulfilled":
+                break
+            if request.status.code in {
+                "schedule-expired",
+                "canceled-before-fulfillment",
+                "bad-parameters",
+                "system-error",
+            }:
                 self.spot_instance_request_id = None
                 self.log_end("")
-                raise Exception("spot instance request failed with result ‘{0}’".format(request.status.code))
+                raise Exception(
+                    "spot instance request failed with result ‘{0}’".format(
+                        request.status.code
+                    )
+                )
             time.sleep(3)
         self.log_end("")
 
-        instance = self._retry(lambda: self._get_instance(instance_id=request.instance_id))
+        instance = self._retry(
+            lambda: self._get_instance(instance_id=request.instance_id)
+        )
 
         return instance
 
-
     def create_instance(self, defn, zone, user_data, ebs_optimized, args):
         IamInstanceProfile = {}
-        if defn.instance_profile.startswith("arn:") :
+        if defn.instance_profile.startswith("arn:"):
             IamInstanceProfile["Arn"] = defn.instance_profile
         else:
             IamInstanceProfile["Name"] = defn.instance_profile
 
         if defn.subnet_id != "":
             if defn.security_groups != [] and defn.security_groups != ["default"]:
-                raise Exception("‘deployment.ec2.securityGroups’ is incompatible with ‘deployment.ec2.subnetId’")
+                raise Exception(
+                    "‘deployment.ec2.securityGroups’ is incompatible with ‘deployment.ec2.subnetId’"
+                )
 
-            args['NetworkInterfaces'] = [dict(
-                AssociatePublicIpAddress=defn.associate_public_ip_address,
-                SubnetId=defn.subnet_id,
-                DeviceIndex=0,
-                Groups=self.security_groups_to_ids(defn.subnet_id, defn.security_group_ids)
-            )]
+            args["NetworkInterfaces"] = [
+                dict(
+                    AssociatePublicIpAddress=defn.associate_public_ip_address,
+                    SubnetId=defn.subnet_id,
+                    DeviceIndex=0,
+                    Groups=self.security_groups_to_ids(
+                        defn.subnet_id, defn.security_group_ids
+                    ),
+                )
+            ]
         else:
-            args['SecurityGroups'] = defn.security_groups
+            args["SecurityGroups"] = defn.security_groups
 
         if defn.spot_instance_price:
             args["InstanceMarketOptions"] = dict(
                 MarketType="spot",
                 SpotOptions=dict(
-                    MaxPrice=str(defn.spot_instance_price/100.0),
+                    MaxPrice=str(defn.spot_instance_price / 100.0),
                     SpotInstanceType=defn.spot_instance_request_type,
-                    InstanceInterruptionBehavior=defn.spot_instance_interruption_behavior
-                )
+                    InstanceInterruptionBehavior=defn.spot_instance_interruption_behavior,
+                ),
             )
             if defn.spot_instance_timeout:
-                args["InstanceMarketOptions"]["SpotOptions"]["ValidUntil"]=(datetime.datetime.utcnow() +
-                    datetime.timedelta(0, defn.spot_instance_timeout)).isoformat()
+                args["InstanceMarketOptions"]["SpotOptions"]["ValidUntil"] = (
+                    datetime.datetime.utcnow()
+                    + datetime.timedelta(0, defn.spot_instance_timeout)
+                ).isoformat()
 
-        placement = dict(
-            AvailabilityZone=zone or ""
-        )
+        placement = dict(AvailabilityZone=zone or "")
         if defn.tenancy:
-            placement['Tenancy'] = defn.tenancy
+            placement["Tenancy"] = defn.tenancy
 
-        args['InstanceType'] = defn.instance_type
-        args['ImageId'] = defn.ami
-        args['IamInstanceProfile'] = IamInstanceProfile
-        args['KeyName'] = defn.key_pair
-        args['Placement'] = placement
-        args['UserData'] = user_data
-        args['EbsOptimized'] = ebs_optimized
-        args['MaxCount'] = 1 # We always want to deploy one instance.
-        args['MinCount'] = 1
+        args["InstanceType"] = defn.instance_type
+        args["ImageId"] = defn.ami
+        args["IamInstanceProfile"] = IamInstanceProfile
+        args["KeyName"] = defn.key_pair
+        args["Placement"] = placement
+        args["UserData"] = user_data
+        args["EbsOptimized"] = ebs_optimized
+        args["MaxCount"] = 1  # We always want to deploy one instance.
+        args["MinCount"] = 1
 
         # Use a client token to ensure that instance creation is
         # idempotent; i.e., if we get interrupted before recording
@@ -765,14 +973,14 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         # next run.
         if not self.client_token:
             with self.depl._db:
-                self.client_token = nixops.util.generate_random_string(length=48) # = 64 ASCII chars
+                self.client_token = nixops.util.generate_random_string(
+                    length=48
+                )  # = 64 ASCII chars
                 self.state = self.STARTING
 
         args["ClientToken"] = self.client_token
 
-        reservation = self._retry(
-            lambda: self._conn_boto3.run_instances(**args)
-        )
+        reservation = self._retry(lambda: self._conn_boto3.run_instances(**args))
 
         if not defn.spot_instance_price:
             # On demand instance, no need to any more checks, return it.
@@ -780,21 +988,32 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
         with self.depl._db:
             self.spot_instance_price = defn.spot_instance_price
-            self.spot_instance_request_id = reservation["Instances"][0]["SpotInstanceRequestId"]
+            self.spot_instance_request_id = reservation["Instances"][0][
+                "SpotInstanceRequestId"
+            ]
 
-        tags = {'Name': "{0} [{1}]".format(self.depl.description, self.name)}
+        tags = {"Name": "{0} [{1}]".format(self.depl.description, self.name)}
         tags.update(defn.tags)
         tags.update(self.get_common_tags())
-        self._retry(lambda: self._conn.create_tags([self.spot_instance_request_id], tags))
+        self._retry(
+            lambda: self._conn.create_tags([self.spot_instance_request_id], tags)
+        )
 
         return self._wait_for_spot_request_fulfillment(self.spot_instance_request_id)
 
     def _cancel_spot_request(self):
-        if self.spot_instance_request_id is None: return
-        self.log_start("cancelling spot instance request ‘{0}’... ".format(self.spot_instance_request_id))
+        if self.spot_instance_request_id is None:
+            return
+        self.log_start(
+            "cancelling spot instance request ‘{0}’... ".format(
+                self.spot_instance_request_id
+            )
+        )
 
         # Cancel the request.
-        request = self._get_spot_instance_request_by_id(self.spot_instance_request_id, allow_missing=True)
+        request = self._get_spot_instance_request_by_id(
+            self.spot_instance_request_id, allow_missing=True
+        )
         if request is not None:
             request.cancel()
 
@@ -802,54 +1021,93 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         # request got fulfilled while we were cancelling it. In that
         # case, record the instance ID.
         while True:
-            request = self._get_spot_instance_request_by_id(self.spot_instance_request_id, allow_missing=True)
-            if request is None: break
+            request = self._get_spot_instance_request_by_id(
+                self.spot_instance_request_id, allow_missing=True
+            )
+            if request is None:
+                break
             self.log_continue("[{0}] ".format(request.status.code))
             if request.instance_id is not None and request.instance_id != self.vm_id:
                 if self.vm_id is not None:
-                    raise Exception("spot instance request got fulfilled unexpectedly as instance ‘{0}’".format(request.instance_id))
+                    raise Exception(
+                        "spot instance request got fulfilled unexpectedly as instance ‘{0}’".format(
+                            request.instance_id
+                        )
+                    )
                 self.vm_id = request.instance_id
-            if request.state != 'open': break
+            if request.state != "open":
+                break
             time.sleep(3)
 
         self.log_end("")
 
         self.spot_instance_request_id = None
 
-
     def after_activation(self, defn):
         # Detach volumes that are no longer in the deployment spec.
         for device_stored, v in self.block_device_mapping.items():
             device_real = device_name_stored_to_real(device_stored)
 
-            if device_stored not in defn.block_device_mapping and not v.get('partOfImage', False):
-                if v.get('disk', '').startswith("ephemeral"):
-                    raise Exception("cannot detach ephemeral device ‘{0}’ from EC2 instance ‘{1}’"
-                    .format(device_real, self.name))
+            if device_stored not in defn.block_device_mapping and not v.get(
+                "partOfImage", False
+            ):
+                if v.get("disk", "").startswith("ephemeral"):
+                    raise Exception(
+                        "cannot detach ephemeral device ‘{0}’ from EC2 instance ‘{1}’".format(
+                            device_real, self.name
+                        )
+                    )
 
-                assert v.get('volumeId', None)
+                assert v.get("volumeId", None)
 
                 self.log("detaching device ‘{0}’...".format(device_real))
-                volumes = self._conn.get_all_volumes([],
-                    filters={'attachment.instance-id': self.vm_id, 'attachment.device': device_stored, 'volume-id': v['volumeId']})
+                volumes = self._conn.get_all_volumes(
+                    [],
+                    filters={
+                        "attachment.instance-id": self.vm_id,
+                        "attachment.device": device_stored,
+                        "volume-id": v["volumeId"],
+                    },
+                )
                 assert len(volumes) <= 1
 
                 if len(volumes) == 1:
-                    if v.get('encrypt', False) and v.get('encryptionType', "luks") == "luks":
-                        device_real_mapper = device_real.replace("/dev/", "/dev/mapper/")
-                        self.run_command("umount -l {0}".format(device_real_mapper), check=False)
-                        self.run_command("cryptsetup luksClose {0}".format(device_real.replace("/dev/", "")), check=False)
+                    if (
+                        v.get("encrypt", False)
+                        and v.get("encryptionType", "luks") == "luks"
+                    ):
+                        device_real_mapper = device_real.replace(
+                            "/dev/", "/dev/mapper/"
+                        )
+                        self.run_command(
+                            "umount -l {0}".format(device_real_mapper), check=False
+                        )
+                        self.run_command(
+                            "cryptsetup luksClose {0}".format(
+                                device_real.replace("/dev/", "")
+                            ),
+                            check=False,
+                        )
                     else:
-                        self.run_command("umount -l {0}".format(device_real), check=False)
-                    if not self._conn.detach_volume(volumes[0].id, instance_id=self.vm_id, device=device_stored):
-                        raise Exception("unable to detach volume ‘{0}’ from EC2 machine ‘{1}’".format(v['volumeId'], self.name))
+                        self.run_command(
+                            "umount -l {0}".format(device_real), check=False
+                        )
+                    if not self._conn.detach_volume(
+                        volumes[0].id, instance_id=self.vm_id, device=device_stored
+                    ):
+                        raise Exception(
+                            "unable to detach volume ‘{0}’ from EC2 machine ‘{1}’".format(
+                                v["volumeId"], self.name
+                            )
+                        )
                         # FIXME: Wait until the volume is actually detached.
 
-                if v.get('charonDeleteOnTermination', False) or v.get('deleteOnTermination', False):
-                    self._delete_volume(v['volumeId'])
+                if v.get("charonDeleteOnTermination", False) or v.get(
+                    "deleteOnTermination", False
+                ):
+                    self._delete_volume(v["volumeId"])
 
                 self.update_block_device_mapping(device_stored, None)
-
 
     def create(self, defn, check, allow_reboot, allow_recreate):
         assert isinstance(defn, EC2Definition)
@@ -860,30 +1118,52 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         self.set_common_state(defn)
 
         if defn.subnet_id.startswith("res-"):
-            res = self.depl.get_typed_resource(defn.subnet_id[4:].split(".")[0], "vpc-subnet")
-            defn.subnet_id = res._state['subnetId']
+            res = self.depl.get_typed_resource(
+                defn.subnet_id[4:].split(".")[0], "vpc-subnet"
+            )
+            defn.subnet_id = res._state["subnetId"]
 
         # Figure out the access key.
-        self.access_key_id = defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+        self.access_key_id = (
+            defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+        )
         if not self.access_key_id:
-            raise Exception("please set ‘deployment.ec2.accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID")
+            raise Exception(
+                "please set ‘deployment.ec2.accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID"
+            )
 
         self.private_key_file = defn.private_key or None
 
         if self.region is None:
             self.region = defn.region
         elif self.region != defn.region:
-            self.warn("cannot change region of a running instance (from ‘{}‘ to ‘{}‘)".format(self.region, defn.region))
+            self.warn(
+                "cannot change region of a running instance (from ‘{}‘ to ‘{}‘)".format(
+                    self.region, defn.region
+                )
+            )
 
         if self.key_pair and self.key_pair != defn.key_pair:
-            raise Exception("cannot change key pair of an existing instance (from ‘{}‘ to ‘{}‘)".format(self.key_pair, defn.key_pair))
+            raise Exception(
+                "cannot change key pair of an existing instance (from ‘{}‘ to ‘{}‘)".format(
+                    self.key_pair, defn.key_pair
+                )
+            )
 
         self.connect()
         self.connect_boto3()
 
         # Stop the instance (if allowed) to change instance attributes
         # such as the type.
-        if self.vm_id and allow_reboot and self._booted_from_ebs() and (self.instance_type != defn.instance_type or self.ebs_optimized != defn.ebs_optimized):
+        if (
+            self.vm_id
+            and allow_reboot
+            and self._booted_from_ebs()
+            and (
+                self.instance_type != defn.instance_type
+                or self.ebs_optimized != defn.ebs_optimized
+            )
+        ):
             self.stop()
             check = True
 
@@ -894,8 +1174,16 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
             if instance is None or instance.state in {"shutting-down", "terminated"}:
                 if not allow_recreate:
-                    raise Exception("EC2 instance ‘{0}’ went away; use ‘--allow-recreate’ to create a new one".format(self.name))
-                self.log("EC2 instance went away (state ‘{0}’), will recreate".format(instance.state if instance else "gone"))
+                    raise Exception(
+                        "EC2 instance ‘{0}’ went away; use ‘--allow-recreate’ to create a new one".format(
+                            self.name
+                        )
+                    )
+                self.log(
+                    "EC2 instance went away (state ‘{0}’), will recreate".format(
+                        instance.state if instance else "gone"
+                    )
+                )
                 self._reset_state()
                 self.region = defn.region
             elif instance.state == "stopped":
@@ -903,12 +1191,20 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
                 # Modify the instance type, if desired.
                 if self.instance_type != defn.instance_type:
-                    self.log("changing instance type from ‘{0}’ to ‘{1}’...".format(self.instance_type, defn.instance_type))
+                    self.log(
+                        "changing instance type from ‘{0}’ to ‘{1}’...".format(
+                            self.instance_type, defn.instance_type
+                        )
+                    )
                     instance.modify_attribute("instanceType", defn.instance_type)
                     self.instance_type = defn.instance_type
 
                 if self.ebs_optimized != defn.ebs_optimized:
-                    self.log("changing ebs optimized flag from ‘{0}’ to ‘{1}’...".format(self.ebs_optimized, defn.ebs_optimized))
+                    self.log(
+                        "changing ebs optimized flag from ‘{0}’ to ‘{1}’...".format(
+                            self.ebs_optimized, defn.ebs_optimized
+                        )
+                    )
                     instance.modify_attribute("ebsOptimized", defn.ebs_optimized)
                     self.ebs_optimized = defn.ebs_optimized
 
@@ -926,8 +1222,11 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         # Create the instance.
         if not self.vm_id:
 
-            self.log("creating EC2 instance (AMI ‘{0}’, type ‘{1}’, region ‘{2}’)...".format(
-                defn.ami, defn.instance_type, self.region))
+            self.log(
+                "creating EC2 instance (AMI ‘{0}’, type ‘{1}’, region ‘{2}’)...".format(
+                    defn.ami, defn.instance_type, self.region
+                )
+            )
             if not self.client_token and not self.spot_instance_request_id:
                 self._reset_state()
                 self.region = defn.region
@@ -936,83 +1235,104 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             # Figure out whether this AMI is EBS-backed.
             amis = self._conn_boto3.describe_images(ImageIds=[defn.ami])
             if len(amis) == 0:
-                raise Exception("AMI ‘{0}’ does not exist in region ‘{1}’".format(defn.ami, self.region))
-            ami = self._conn_boto3.describe_images(ImageIds=[defn.ami])['Images'][0]
-            self.root_device_type = ami['RootDeviceType']
+                raise Exception(
+                    "AMI ‘{0}’ does not exist in region ‘{1}’".format(
+                        defn.ami, self.region
+                    )
+                )
+            ami = self._conn_boto3.describe_images(ImageIds=[defn.ami])["Images"][0]
+            self.root_device_type = ami["RootDeviceType"]
 
             # Check if we need to resize the root disk
-            resize_root = defn.root_disk_size != 0 and ami['RootDeviceType'] == 'ebs'
+            resize_root = defn.root_disk_size != 0 and ami["RootDeviceType"] == "ebs"
 
             args = dict()
 
             # Set the initial block device mapping to the ephemeral
             # devices defined in the spec.  These cannot be changed
             # later.
-            args['BlockDeviceMappings'] = []
+            args["BlockDeviceMappings"] = []
 
             for device_stored, v in defn.block_device_mapping.iteritems():
                 device_real = device_name_stored_to_real(device_stored)
                 # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/device_naming.html
-                ebs_disk = not v['disk'].startswith("ephemeral")
+                ebs_disk = not v["disk"].startswith("ephemeral")
 
                 # though /dev/nvme0 is to not recommended, it's not possible that it will appear here, because /dev/nvme0 is always attached as root
-                device_name_not_recommended_for_ebs_disks = re.match("/dev/xvd[a-e]", device_real)
+                device_name_not_recommended_for_ebs_disks = re.match(
+                    "/dev/xvd[a-e]", device_real
+                )
 
                 if ebs_disk and device_name_not_recommended_for_ebs_disks:
-                    raise Exception("non-ephemeral disk not allowed on device ‘{0}’; use /dev/xvdf or higher".format(device_real))
+                    raise Exception(
+                        "non-ephemeral disk not allowed on device ‘{0}’; use /dev/xvdf or higher".format(
+                            device_real
+                        )
+                    )
 
-                if v['disk'].startswith("ephemeral"):
+                if v["disk"].startswith("ephemeral"):
                     ephemeral_mapping = dict(
                         DeviceName=device_name_to_boto_expected(device_real),
-                        VirtualName=v['disk']
+                        VirtualName=v["disk"],
                     )
-                    args['BlockDeviceMappings'].append(ephemeral_mapping)
+                    args["BlockDeviceMappings"].append(ephemeral_mapping)
                     self.update_block_device_mapping(device_stored, v)
 
-            root_device = ami['RootDeviceName']
+            root_device = ami["RootDeviceName"]
             if resize_root:
                 root_mapping = dict(
                     DeviceName=root_device,
                     Ebs=dict(
                         DeleteOnTermination=True,
                         VolumeSize=defn.root_disk_size,
-                        VolumeType=ami['BlockDeviceMappings'][0]['Ebs']['VolumeType']
-                    )
+                        VolumeType=ami["BlockDeviceMappings"][0]["Ebs"]["VolumeType"],
+                    ),
                 )
-                args['BlockDeviceMappings'].append(root_mapping)
+                args["BlockDeviceMappings"].append(root_mapping)
             # If we're attaching any EBS volumes, then make sure that
             # we create the instance in the right placement zone.
             zone = defn.zone or None
             for device_stored, v in defn.block_device_mapping.iteritems():
-                if not v['disk'].startswith("vol-"): continue
+                if not v["disk"].startswith("vol-"):
+                    continue
                 # Make note of the placement zone of the volume.
-                volume = nixopsaws.ec2_utils.get_volume_by_id(self._conn, v['disk'])
+                volume = nixopsaws.ec2_utils.get_volume_by_id(self._conn, v["disk"])
                 if not zone:
-                    self.log("starting EC2 instance in zone ‘{0}’ due to volume ‘{1}’".format(
-                            volume.zone, v['disk']))
+                    self.log(
+                        "starting EC2 instance in zone ‘{0}’ due to volume ‘{1}’".format(
+                            volume.zone, v["disk"]
+                        )
+                    )
                     zone = volume.zone
                 elif zone != volume.zone:
-                    raise Exception("unable to start EC2 instance ‘{0}’ in zone ‘{1}’ because volume ‘{2}’ is in zone ‘{3}’"
-                                    .format(self.name, zone, v['disk'], volume.zone))
+                    raise Exception(
+                        "unable to start EC2 instance ‘{0}’ in zone ‘{1}’ because volume ‘{2}’ is in zone ‘{3}’".format(
+                            self.name, zone, v["disk"], volume.zone
+                        )
+                    )
 
             # Do we want an EBS-optimized instance?
             prefer_ebs_optimized = False
             for device_stored, v in defn.block_device_mapping.iteritems():
-                if v['volumeType'] != "standard":
+                if v["volumeType"] != "standard":
                     prefer_ebs_optimized = True
 
             # if we have PIOPS volume and instance type supports EBS Optimized flags, then use ebs_optimized
             ebs_optimized = prefer_ebs_optimized and defn.ebs_optimized
             # Generate a public/private host key.
             if not self.public_host_key:
-                (private, public) = nixops.util.create_key_pair(type=defn.host_key_type())
+                (private, public) = nixops.util.create_key_pair(
+                    type=defn.host_key_type()
+                )
                 with self.depl._db:
                     self.public_host_key = public
                     self.private_host_key = private
 
             user_data = "SSH_HOST_{2}_KEY_PUB:{0}\nSSH_HOST_{2}_KEY:{1}\n".format(
-                self.public_host_key, self.private_host_key.replace("\n", "|"),
-                defn.host_key_type().upper())
+                self.public_host_key,
+                self.private_host_key.replace("\n", "|"),
+                defn.host_key_type().upper(),
+            )
 
             instance = self.create_instance(defn, zone, user_data, ebs_optimized, args)
             update_instance_profile = False
@@ -1036,13 +1356,15 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             if defn.spot_instance_request_type == "one-time":
                 self._cancel_spot_request()
 
-
         # There is a short time window during which EC2 doesn't
         # know the instance ID yet.  So wait until it does.
         if self.state != self.UP or check:
             while True:
-                if self._get_instance(allow_missing=True): break
-                self.log("EC2 instance ‘{0}’ not known yet, waiting...".format(self.vm_id))
+                if self._get_instance(allow_missing=True):
+                    break
+                self.log(
+                    "EC2 instance ‘{0}’ not known yet, waiting...".format(self.vm_id)
+                )
                 time.sleep(3)
 
         if not self.virtualization_type:
@@ -1052,51 +1374,107 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
         # Warn about some EC2 options that we cannot update for an existing instance.
         if self.instance_type != defn.instance_type:
-            self.warn("cannot change type of a running instance (from ‘{0}‘ to ‘{1}‘): use ‘--allow-reboot’".format(self.instance_type, defn.instance_type))
-        if self.ebs_optimized and self.ebs_optimized != defn.ebs_optimized:
-            self.warn("cannot change ebs optimized attribute of a running instance: use ‘--allow-reboot’")
-        if defn.zone and self.zone != defn.zone:
-            self.warn("cannot change availability zone of a running (from ‘{0}‘ to ‘{1}‘)".format(self.zone, defn.zone))
-        if not defn.subnet_id and not instance.subnet_id and set(defn.security_groups) != set(self.security_groups):
             self.warn(
-                'cannot change security groups of an existing instance (from [{0}] to [{1}])'.format(
+                "cannot change type of a running instance (from ‘{0}‘ to ‘{1}‘): use ‘--allow-reboot’".format(
+                    self.instance_type, defn.instance_type
+                )
+            )
+        if self.ebs_optimized and self.ebs_optimized != defn.ebs_optimized:
+            self.warn(
+                "cannot change ebs optimized attribute of a running instance: use ‘--allow-reboot’"
+            )
+        if defn.zone and self.zone != defn.zone:
+            self.warn(
+                "cannot change availability zone of a running (from ‘{0}‘ to ‘{1}‘)".format(
+                    self.zone, defn.zone
+                )
+            )
+        if (
+            not defn.subnet_id
+            and not instance.subnet_id
+            and set(defn.security_groups) != set(self.security_groups)
+        ):
+            self.warn(
+                "cannot change security groups of an existing instance (from [{0}] to [{1}])".format(
                     ", ".join(set(self.security_groups)),
-                    ", ".join(set(defn.security_groups)))
+                    ", ".join(set(defn.security_groups)),
+                )
             )
 
         instance_groups = [g.id for g in instance.groups]
         if defn.subnet_id:
-            new_instance_groups = self.security_groups_to_ids(defn.subnet_id, defn.security_group_ids)
+            new_instance_groups = self.security_groups_to_ids(
+                defn.subnet_id, defn.security_group_ids
+            )
         elif instance.vpc_id:
-            new_instance_groups = self.security_groups_to_ids(instance.subnet_id, defn.security_groups)
+            new_instance_groups = self.security_groups_to_ids(
+                instance.subnet_id, defn.security_groups
+            )
 
         if instance.vpc_id and set(instance_groups) != set(new_instance_groups):
-            self.log("updating security groups from {0} to {1}...".format(instance_groups, new_instance_groups))
+            self.log(
+                "updating security groups from {0} to {1}...".format(
+                    instance_groups, new_instance_groups
+                )
+            )
             instance.modify_attribute("groupSet", new_instance_groups)
 
         if defn.placement_group != (self.placement_group or ""):
             self.warn(
-                'cannot change placement group of an existing instance (from ‘{0}’ to ‘{1}’)'.format(
-                    self.placement_group or "",
-                    defn.placement_group)
+                "cannot change placement group of an existing instance (from ‘{0}’ to ‘{1}’)".format(
+                    self.placement_group or "", defn.placement_group
+                )
             )
 
         # update iam instance profiles of instance
-        if update_instance_profile and (self.instance_profile != defn.instance_profile or check):
-            assocs = self._retry(lambda: self._conn_boto3.describe_iam_instance_profile_associations(Filters=[{ 'Name': 'instance-id', 'Values': [self.vm_id]}])['IamInstanceProfileAssociations'])
-            if len(assocs) > 0 and self.instance_profile != assocs[0]['IamInstanceProfile']['Arn']:
-                self.log("disassociating instance profile {}".format(assocs[0]['IamInstanceProfile']['Arn']))
-                self._conn_boto3.disassociate_iam_instance_profile(AssociationId=assocs[0]['AssociationId'])
-                nixops.util.check_wait(lambda: len(self._retry(lambda: self._conn_boto3.describe_iam_instance_profile_associations(Filters=[{ 'Name': 'instance-id', 'Values': [self.vm_id]}])['IamInstanceProfileAssociations'])) == 0 )
-
+        if update_instance_profile and (
+            self.instance_profile != defn.instance_profile or check
+        ):
+            assocs = self._retry(
+                lambda: self._conn_boto3.describe_iam_instance_profile_associations(
+                    Filters=[{"Name": "instance-id", "Values": [self.vm_id]}]
+                )["IamInstanceProfileAssociations"]
+            )
+            if (
+                len(assocs) > 0
+                and self.instance_profile != assocs[0]["IamInstanceProfile"]["Arn"]
+            ):
+                self.log(
+                    "disassociating instance profile {}".format(
+                        assocs[0]["IamInstanceProfile"]["Arn"]
+                    )
+                )
+                self._conn_boto3.disassociate_iam_instance_profile(
+                    AssociationId=assocs[0]["AssociationId"]
+                )
+                nixops.util.check_wait(
+                    lambda: len(
+                        self._retry(
+                            lambda: self._conn_boto3.describe_iam_instance_profile_associations(
+                                Filters=[
+                                    {"Name": "instance-id", "Values": [self.vm_id]}
+                                ]
+                            )[
+                                "IamInstanceProfileAssociations"
+                            ]
+                        )
+                    )
+                    == 0
+                )
 
             if defn.instance_profile != "":
-                if defn.instance_profile.startswith('arn:'):
-                    iip = { 'Arn': defn.instance_profile }
+                if defn.instance_profile.startswith("arn:"):
+                    iip = {"Arn": defn.instance_profile}
                 else:
-                    iip = { 'Name': defn.instance_profile }
-                self.log("associating instance profile {}".format(defn.instance_profile))
-                self._retry(lambda: self._conn_boto3.associate_iam_instance_profile(IamInstanceProfile=iip, InstanceId=self.vm_id))
+                    iip = {"Name": defn.instance_profile}
+                self.log(
+                    "associating instance profile {}".format(defn.instance_profile)
+                )
+                self._retry(
+                    lambda: self._conn_boto3.associate_iam_instance_profile(
+                        IamInstanceProfile=iip, InstanceId=self.vm_id
+                    )
+                )
 
             with self.depl._db:
                 self.instance_profile = defn.instance_profile
@@ -1104,7 +1482,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         # Reapply tags if they have changed.
         common_tags = defn.tags
         if defn.owners != []:
-            common_tags['Owners'] = ", ".join(defn.owners)
+            common_tags["Owners"] = ", ".join(defn.owners)
         self.update_tags(self.vm_id, user_tags=common_tags, check=check)
 
         # Reapply sourceDestCheck if it has changed.
@@ -1124,11 +1502,11 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             self.associate_public_ip_address = defn.associate_public_ip_address
 
         # Wait for the IP address.
-        if (self.associate_public_ip_address and not self.public_ipv4) \
-           or \
-           (self.use_private_ip_address and not self.private_ipv4) \
-           or \
-           check:
+        if (
+            (self.associate_public_ip_address and not self.public_ipv4)
+            or (self.use_private_ip_address and not self.private_ipv4)
+            or check
+        ):
             self._wait_for_ip()
 
         if defn.dns_hostname:
@@ -1144,42 +1522,67 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             self.log("replacing temporary host key...")
             key_type = defn.host_key_type()
             new_key = self.run_command(
-                "rm -f /etc/ssh/ssh_host_{0}_key*; systemctl restart sshd; cat /etc/ssh/ssh_host_{0}_key.pub"
-                .format(key_type),
-                capture_stdout=True).rstrip()
+                "rm -f /etc/ssh/ssh_host_{0}_key*; systemctl restart sshd; cat /etc/ssh/ssh_host_{0}_key.pub".format(
+                    key_type
+                ),
+                capture_stdout=True,
+            ).rstrip()
             self.public_host_key = new_key
-            nixops.known_hosts.update(None, self._ip_for_ssh_key(), self.public_host_key)
+            nixops.known_hosts.update(
+                None, self._ip_for_ssh_key(), self.public_host_key
+            )
 
         # Add disks that were in the original device mapping of image.
         if self.first_boot:
             for device_stored, dm in self._get_instance().block_device_mapping.items():
                 if device_stored not in self.block_device_mapping and dm.volume_id:
-                    bdm = {'volumeId': dm.volume_id, 'partOfImage': True}
-                    self.update_block_device_mapping(device_stored, bdm) # TODO: it stores root device as sd though its really attached as nvme
+                    bdm = {"volumeId": dm.volume_id, "partOfImage": True}
+                    self.update_block_device_mapping(
+                        device_stored, bdm
+                    )  # TODO: it stores root device as sd though its really attached as nvme
             self.first_boot = False
 
         # Detect if volumes were manually detached.  If so, reattach
         # them.
         for device_stored, v in self.block_device_mapping.items():
-            if device_name_to_boto_expected(device_stored) not in self._get_instance().block_device_mapping.keys() and not v.get('needsAttach', False) and v.get('volumeId', None):
+            if (
+                device_name_to_boto_expected(device_stored)
+                not in self._get_instance().block_device_mapping.keys()
+                and not v.get("needsAttach", False)
+                and v.get("volumeId", None)
+            ):
                 device_real = device_name_stored_to_real(device_stored)
                 self.warn("device ‘{0}’ was manually detached!".format(device_real))
-                v['needsAttach'] = True
+                v["needsAttach"] = True
                 self.update_block_device_mapping(device_stored, v)
 
         # Detect if volumes were manually destroyed.
         for device_stored, v in self.block_device_mapping.items():
-            if v.get('needsAttach', False):
-                volume = nixopsaws.ec2_utils.get_volume_by_id(self._conn, v['volumeId'], allow_missing=True)
-                if volume: continue
+            if v.get("needsAttach", False):
+                volume = nixopsaws.ec2_utils.get_volume_by_id(
+                    self._conn, v["volumeId"], allow_missing=True
+                )
+                if volume:
+                    continue
                 if device_stored not in defn.block_device_mapping:
-                    self.warn("forgetting about volume ‘{0}’ that no longer exists and is no longer needed by the deployment specification".format(v['volumeId']))
+                    self.warn(
+                        "forgetting about volume ‘{0}’ that no longer exists and is no longer needed by the deployment specification".format(
+                            v["volumeId"]
+                        )
+                    )
                 else:
                     if not allow_recreate:
-                        raise Exception("volume ‘{0}’ (used by EC2 instance ‘{1}’) no longer exists; "
-                                        "run ‘nixops stop’, then ‘nixops deploy --allow-recreate’ to create a new, empty volume"
-                                        .format(v['volumeId'], self.name))
-                    self.warn("volume ‘{0}’ has disappeared; will create an empty volume to replace it".format(v['volumeId']))
+                        raise Exception(
+                            "volume ‘{0}’ (used by EC2 instance ‘{1}’) no longer exists; "
+                            "run ‘nixops stop’, then ‘nixops deploy --allow-recreate’ to create a new, empty volume".format(
+                                v["volumeId"], self.name
+                            )
+                        )
+                    self.warn(
+                        "volume ‘{0}’ has disappeared; will create an empty volume to replace it".format(
+                            v["volumeId"]
+                        )
+                    )
                 self.update_block_device_mapping(device_stored, None)
 
         # Create missing volumes.
@@ -1187,53 +1590,81 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             device_real = device_name_stored_to_real(device_stored)
 
             volume = None
-            if v['disk'] == '':
-                if device_stored in self.block_device_mapping: continue
-                self.log("creating EBS volume of {0} GiB...".format(v['size']))
-                ebs_encrypt = v.get('encryptionType', "luks") == "ebs"
-                volume = self._conn.create_volume(size=v['size'], zone=self.zone, volume_type=v['volumeType'], iops=v['iops'], encrypted=ebs_encrypt)
-                v['volumeId'] = volume.id
-
-            elif v['disk'].startswith("vol-"):
+            if v["disk"] == "":
                 if device_stored in self.block_device_mapping:
-                    cur_volume_id = self.block_device_mapping[device_stored]['volumeId']
-                    if cur_volume_id != v['disk']:
-                        raise Exception("cannot attach EBS volume ‘{0}’ to ‘{1}’ because volume ‘{2}’ is already attached there".format(v['disk'], device_real, cur_volume_id))
                     continue
-                v['volumeId'] = v['disk']
+                self.log("creating EBS volume of {0} GiB...".format(v["size"]))
+                ebs_encrypt = v.get("encryptionType", "luks") == "ebs"
+                volume = self._conn.create_volume(
+                    size=v["size"],
+                    zone=self.zone,
+                    volume_type=v["volumeType"],
+                    iops=v["iops"],
+                    encrypted=ebs_encrypt,
+                )
+                v["volumeId"] = volume.id
 
-            elif v['disk'].startswith("res-"):
-                res_name = v['disk'][4:]
+            elif v["disk"].startswith("vol-"):
+                if device_stored in self.block_device_mapping:
+                    cur_volume_id = self.block_device_mapping[device_stored]["volumeId"]
+                    if cur_volume_id != v["disk"]:
+                        raise Exception(
+                            "cannot attach EBS volume ‘{0}’ to ‘{1}’ because volume ‘{2}’ is already attached there".format(
+                                v["disk"], device_real, cur_volume_id
+                            )
+                        )
+                    continue
+                v["volumeId"] = v["disk"]
+
+            elif v["disk"].startswith("res-"):
+                res_name = v["disk"][4:]
                 res = self.depl.get_typed_resource(res_name, "ebs-volume")
                 if res.state != self.UP:
-                    raise Exception("EBS volume ‘{0}’ has not been created yet".format(res_name))
+                    raise Exception(
+                        "EBS volume ‘{0}’ has not been created yet".format(res_name)
+                    )
                 assert res.volume_id
                 if device_stored in self.block_device_mapping:
-                    cur_volume_id = self.block_device_mapping[device_stored]['volumeId']
+                    cur_volume_id = self.block_device_mapping[device_stored]["volumeId"]
                     if cur_volume_id != res.volume_id:
-                        raise Exception("cannot attach EBS volume ‘{0}’ to ‘{1}’ because volume ‘{2}’ is already attached there".format(res_name, device_real, cur_volume_id))
+                        raise Exception(
+                            "cannot attach EBS volume ‘{0}’ to ‘{1}’ because volume ‘{2}’ is already attached there".format(
+                                res_name, device_real, cur_volume_id
+                            )
+                        )
                     continue
-                v['volumeId'] = res.volume_id
+                v["volumeId"] = res.volume_id
 
-            elif v['disk'].startswith("snap-"):
-                if device_stored in self.block_device_mapping: continue
-                self.log("creating volume from snapshot ‘{0}’...".format(v['disk']))
-                volume = self._conn.create_volume(size=v['size'], snapshot=v['disk'], zone=self.zone, volume_type=v['volumeType'], iops=v['iops'])
-                v['volumeId'] = volume.id
+            elif v["disk"].startswith("snap-"):
+                if device_stored in self.block_device_mapping:
+                    continue
+                self.log("creating volume from snapshot ‘{0}’...".format(v["disk"]))
+                volume = self._conn.create_volume(
+                    size=v["size"],
+                    snapshot=v["disk"],
+                    zone=self.zone,
+                    volume_type=v["volumeType"],
+                    iops=v["iops"],
+                )
+                v["volumeId"] = volume.id
 
             else:
                 if device_stored in self.block_device_mapping:
-                    v['needsAttach'] = False
+                    v["needsAttach"] = False
                     self.update_block_device_mapping(device_stored, v)
                     continue
-                raise Exception("adding device mapping ‘{0}’ to a running instance is not (yet) supported".format(v['disk']))
+                raise Exception(
+                    "adding device mapping ‘{0}’ to a running instance is not (yet) supported".format(
+                        v["disk"]
+                    )
+                )
 
             # ‘charonDeleteOnTermination’ denotes whether we have to
             # delete the volume.  This is distinct from
             # ‘deleteOnTermination’ for backwards compatibility with
             # the time that we still used auto-created volumes.
-            v['charonDeleteOnTermination'] = v['deleteOnTermination']
-            v['needsAttach'] = True
+            v["charonDeleteOnTermination"] = v["deleteOnTermination"]
+            v["needsAttach"] = True
             self.update_block_device_mapping(device_stored, v)
 
             # Wait for volume to get to available state for newly
@@ -1242,40 +1673,62 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             # in-use).  Doing this after updating the device mapping
             # state, to make it recoverable in case an exception
             # happens (e.g. in other machine's deployments).
-            if volume: nixopsaws.ec2_utils.wait_for_volume_available(self._conn, volume.id, self.logger)
+            if volume:
+                nixopsaws.ec2_utils.wait_for_volume_available(
+                    self._conn, volume.id, self.logger
+                )
 
         # Always apply tags to the volumes we just created.
         for device_stored, v in self.block_device_mapping.items():
             device_real = device_name_stored_to_real(device_stored)
 
-            if not (('disk' in v and not (v['disk'].startswith("ephemeral")
-                                          or v['disk'].startswith("res-")
-                                          or v['disk'].startswith("vol-")))
-                    or 'partOfImage' in v): continue
+            if not (
+                (
+                    "disk" in v
+                    and not (
+                        v["disk"].startswith("ephemeral")
+                        or v["disk"].startswith("res-")
+                        or v["disk"].startswith("vol-")
+                    )
+                )
+                or "partOfImage" in v
+            ):
+                continue
             volume_tags = {}
             volume_tags.update(common_tags)
             volume_tags.update(defn.tags)
-            volume_tags['Name'] = "{0} [{1} - {2}]".format(self.depl.description, self.name, device_real)
-            self._retry(lambda: self._conn.create_tags([v['volumeId']], volume_tags))
+            volume_tags["Name"] = "{0} [{1} - {2}]".format(
+                self.depl.description, self.name, device_real
+            )
+            self._retry(lambda: self._conn.create_tags([v["volumeId"]], volume_tags))
 
         # Attach missing volumes.
 
         for device_stored, v in self.sorted_block_device_mapping():
-            if v.get('needsAttach', False):
-                self.attach_volume(device_stored, v['volumeId'])
-                del v['needsAttach']
+            if v.get("needsAttach", False):
+                self.attach_volume(device_stored, v["volumeId"])
+                del v["needsAttach"]
                 self.update_block_device_mapping(device_stored, v)
 
         # FIXME: process changes to the deleteOnTermination flag.
 
         # Auto-generate LUKS keys if the model didn't specify one.
         for device_stored, v in self.block_device_mapping.items():
-            if v.get('encrypt', False) and v.get('passphrase', "") == "" and v.get('generatedKey', "") == "" and v.get('encryptionType', "luks") == "luks":
-                v['generatedKey'] = nixops.util.generate_random_string(length=256)
+            if (
+                v.get("encrypt", False)
+                and v.get("passphrase", "") == ""
+                and v.get("generatedKey", "") == ""
+                and v.get("encryptionType", "luks") == "luks"
+            ):
+                v["generatedKey"] = nixops.util.generate_random_string(length=256)
                 self.update_block_device_mapping(device_stored, v)
 
     def _retry_route53(self, f, error_codes=[]):
-        return nixopsaws.ec2_utils.retry(f, error_codes = ['Throttling', 'PriorRequestNotComplete']+error_codes, logger=self)
+        return nixopsaws.ec2_utils.retry(
+            f,
+            error_codes=["Throttling", "PriorRequestNotComplete"] + error_codes,
+            logger=self,
+        )
 
     def _update_route53(self, defn):
         import boto.route53
@@ -1283,25 +1736,43 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
         self.dns_hostname = defn.dns_hostname.lower()
         self.dns_ttl = defn.dns_ttl
-        self.route53_access_key_id = defn.route53_access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+        self.route53_access_key_id = (
+            defn.route53_access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+        )
         self.route53_use_public_dns_name = defn.route53_use_public_dns_name
         self.route53_private = defn.route53_private
 
         if self.route53_private:
             if self.route53_use_public_dns_name:
-                raise Exception("Can not add record for ‘{0}’, because private CNAME records are not implemented in NixOps. You may choose to use an ‘A’ record instead by setting ‘usePublicDNSName = false’.".format(self.dns_hostname))
+                raise Exception(
+                    "Can not add record for ‘{0}’, because private CNAME records are not implemented in NixOps. You may choose to use an ‘A’ record instead by setting ‘usePublicDNSName = false’.".format(
+                        self.dns_hostname
+                    )
+                )
 
-            record_type = 'A'
+            record_type = "A"
             dns_value = self.private_ipv4
 
         else:
             if not self.public_ipv4:
-                raise Exception("No public ipv4 address has been associated with ‘{0}’. If this record is intended for a public cloud host, make sure it is defined and its public IP address is known to NixOps. If this is record is intended for a private cloud, use ‘private = true’ to use the private IP adress instead.".format(self.dns_hostname))
+                raise Exception(
+                    "No public ipv4 address has been associated with ‘{0}’. If this record is intended for a public cloud host, make sure it is defined and its public IP address is known to NixOps. If this is record is intended for a private cloud, use ‘private = true’ to use the private IP adress instead.".format(
+                        self.dns_hostname
+                    )
+                )
 
-            record_type = 'CNAME' if self.route53_use_public_dns_name else 'A'
-            dns_value = self.public_dns_name if self.route53_use_public_dns_name else self.public_ipv4
+            record_type = "CNAME" if self.route53_use_public_dns_name else "A"
+            dns_value = (
+                self.public_dns_name
+                if self.route53_use_public_dns_name
+                else self.public_ipv4
+            )
 
-        self.log('sending Route53 DNS: {0} {1} {2}'.format(self.dns_hostname, record_type, dns_value))
+        self.log(
+            "sending Route53 DNS: {0} {1} {2}".format(
+                self.dns_hostname, record_type, dns_value
+            )
+        )
 
         self.connect_route53()
 
@@ -1311,72 +1782,97 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         def testzone(hosted_zone, zone):
             """returns True if there is a subcomponent match"""
             hostparts = hosted_zone.split(".")
-            zoneparts = zone.Name.split(".")[:-1] # strip the last ""
+            zoneparts = zone.Name.split(".")[:-1]  # strip the last ""
 
-            return hostparts[::-1][:len(zoneparts)][::-1] == zoneparts
+            return hostparts[::-1][: len(zoneparts)][::-1] == zoneparts
 
-        zones = [zone for zone in zones['ListHostedZonesResponse']['HostedZones'] if testzone(hosted_zone, zone)]
+        zones = [
+            zone
+            for zone in zones["ListHostedZonesResponse"]["HostedZones"]
+            if testzone(hosted_zone, zone)
+        ]
         if len(zones) == 0:
-            raise Exception('hosted zone for {0} not found'.format(hosted_zone))
+            raise Exception("hosted zone for {0} not found".format(hosted_zone))
 
         # use hosted zone with longest match
-        zones = sorted(zones, cmp=lambda a, b: cmp(len(a.Name), len(b.Name)), reverse=True)
-        zoneid = zones[0]['Id'].split("/")[2]
-        dns_name = '{0}.'.format(self.dns_hostname)
+        zones = sorted(
+            zones, cmp=lambda a, b: cmp(len(a.Name), len(b.Name)), reverse=True
+        )
+        zoneid = zones[0]["Id"].split("/")[2]
+        dns_name = "{0}.".format(self.dns_hostname)
 
-        prev_a_rrs = [prev for prev
-                      in self._retry_route53(lambda: self._conn_route53.get_all_rrsets(
-                          hosted_zone_id=zoneid,
-                          type="A",
-                          name=dns_name
-                      ))
-                      if prev.name == dns_name
-                      and prev.type == "A"]
+        prev_a_rrs = [
+            prev
+            for prev in self._retry_route53(
+                lambda: self._conn_route53.get_all_rrsets(
+                    hosted_zone_id=zoneid, type="A", name=dns_name
+                )
+            )
+            if prev.name == dns_name and prev.type == "A"
+        ]
 
-        prev_cname_rrs = [prev for prev
-                          in self._retry_route53(lambda: self._conn_route53.get_all_rrsets(
-                              hosted_zone_id=zoneid,
-                              type="CNAME",
-                              name=self.dns_hostname
-                          ))
-                          if prev.name == dns_name
-                          and prev.type == "CNAME"]
+        prev_cname_rrs = [
+            prev
+            for prev in self._retry_route53(
+                lambda: self._conn_route53.get_all_rrsets(
+                    hosted_zone_id=zoneid, type="CNAME", name=self.dns_hostname
+                )
+            )
+            if prev.name == dns_name and prev.type == "CNAME"
+        ]
 
-        changes = boto.route53.record.ResourceRecordSets(connection=self._conn_route53, hosted_zone_id=zoneid)
+        changes = boto.route53.record.ResourceRecordSets(
+            connection=self._conn_route53, hosted_zone_id=zoneid
+        )
         if len(prev_a_rrs) > 0:
             for prevrr in prev_a_rrs:
-                change = changes.add_change("DELETE", self.dns_hostname, "A", ttl=prevrr.ttl)
+                change = changes.add_change(
+                    "DELETE", self.dns_hostname, "A", ttl=prevrr.ttl
+                )
                 change.add_value(",".join(prevrr.resource_records))
         if len(prev_cname_rrs) > 0:
             for prevrr in prev_cname_rrs:
-                change = changes.add_change("DELETE", prevrr.name, "CNAME", ttl=prevrr.ttl)
+                change = changes.add_change(
+                    "DELETE", prevrr.name, "CNAME", ttl=prevrr.ttl
+                )
                 change.add_value(",".join(prevrr.resource_records))
 
-        change = changes.add_change("CREATE", self.dns_hostname, record_type, ttl=self.dns_ttl)
+        change = changes.add_change(
+            "CREATE", self.dns_hostname, record_type, ttl=self.dns_ttl
+        )
         change.add_value(dns_value)
         # add InvalidChangeBatch to error codes to retry on. Unfortunately AWS sometimes returns
         # this due to eventual consistency
-        self._retry_route53(lambda: changes.commit(), error_codes=['InvalidChangeBatch'])
-
+        self._retry_route53(
+            lambda: changes.commit(), error_codes=["InvalidChangeBatch"]
+        )
 
     def _delete_volume(self, volume_id, allow_keep=False):
-        if not self.depl.logger.confirm("are you sure you want to destroy EBS volume ‘{0}’?".format(volume_id)):
+        if not self.depl.logger.confirm(
+            "are you sure you want to destroy EBS volume ‘{0}’?".format(volume_id)
+        ):
             if allow_keep:
                 return
             else:
                 raise Exception("not destroying EBS volume ‘{0}’".format(volume_id))
         self.log("destroying EBS volume ‘{0}’...".format(volume_id))
-        volume = nixopsaws.ec2_utils.get_volume_by_id(self.connect(), volume_id, allow_missing=True)
-        if not volume: return
-        nixops.util.check_wait(lambda: volume.update() == 'available')
+        volume = nixopsaws.ec2_utils.get_volume_by_id(
+            self.connect(), volume_id, allow_missing=True
+        )
+        if not volume:
+            return
+        nixops.util.check_wait(lambda: volume.update() == "available")
         volume.delete()
-
 
     def destroy(self, wipe=False):
         self._cancel_spot_request()
 
-        if not (self.vm_id or self.client_token): return True
-        if not self.depl.logger.confirm("are you sure you want to destroy EC2 machine ‘{0}’?".format(self.name)): return False
+        if not (self.vm_id or self.client_token):
+            return True
+        if not self.depl.logger.confirm(
+            "are you sure you want to destroy EC2 machine ‘{0}’?".format(self.name)
+        ):
+            return False
 
         if wipe:
             log.warn("wipe is not supported")
@@ -1392,7 +1888,9 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         if self.vm_id:
             instance = self._get_instance(allow_missing=True)
         else:
-            reservations = self._conn.get_all_instances(filters={'client-token': self.client_token})
+            reservations = self._conn.get_all_instances(
+                filters={"client-token": self.client_token}
+            )
             if len(reservations) > 0:
                 instance = reservations[0].instances[0]
 
@@ -1402,7 +1900,8 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             # Wait until it's really terminated.
             while True:
                 self.log_continue("[{0}] ".format(instance.state))
-                if instance.state == "terminated": break
+                if instance.state == "terminated":
+                    break
                 time.sleep(3)
                 instance = self._get_instance(update=True)
 
@@ -1412,19 +1911,20 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
         # Destroy volumes created for this instance.
         for device_stored, v in self.block_device_mapping.items():
-            if v.get('charonDeleteOnTermination', False):
-                self._delete_volume(v['volumeId'], True)
+            if v.get("charonDeleteOnTermination", False):
+                self._delete_volume(v["volumeId"], True)
                 self.update_block_device_mapping(device_stored, None)
 
         return True
-
 
     def stop(self):
         if not self._booted_from_ebs():
             self.warn("cannot stop non-EBS-backed instance")
             return
 
-        if not self.depl.logger.confirm("are you sure you want to stop machine '{}'".format(self.name)):
+        if not self.depl.logger.confirm(
+            "are you sure you want to stop machine '{}'".format(self.name)
+        ):
             return
 
         self.log_start("stopping EC2 machine... ")
@@ -1442,27 +1942,34 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                 return True
             if instance.state not in {"running", "stopping"}:
                 raise Exception(
-                    "EC2 instance ‘{0}’ failed to stop (state is ‘{1}’)"
-                    .format(self.vm_id, instance.state))
+                    "EC2 instance ‘{0}’ failed to stop (state is ‘{1}’)".format(
+                        self.vm_id, instance.state
+                    )
+                )
             return False
 
-        if not nixops.util.check_wait(check_stopped, initial=3, max_tries=300, exception=False): # = 15 min
+        if not nixops.util.check_wait(
+            check_stopped, initial=3, max_tries=300, exception=False
+        ):  # = 15 min
             # If stopping times out, then do an unclean shutdown.
             self.log_end("(timed out)")
             self.log_start("force-stopping EC2 machine... ")
             instance.stop(force=True)
-            if not nixops.util.check_wait(check_stopped, initial=3, max_tries=100, exception=False): # = 5 min
+            if not nixops.util.check_wait(
+                check_stopped, initial=3, max_tries=100, exception=False
+            ):  # = 5 min
                 # Amazon docs suggest doing a force stop twice...
                 self.log_end("(timed out)")
                 self.log_start("force-stopping EC2 machine... ")
                 instance.stop(force=True)
-                nixops.util.check_wait(check_stopped, initial=3, max_tries=100) # = 5 min
+                nixops.util.check_wait(
+                    check_stopped, initial=3, max_tries=100
+                )  # = 5 min
 
         self.log_end("")
 
         self.state = self.STOPPED
         self.ssh_master = None
-
 
     def start(self):
         if not self._booted_from_ebs():
@@ -1487,12 +1994,14 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
 
         self._wait_for_ip()
 
-        if prev_private_ipv4 != self.private_ipv4 or prev_public_ipv4 != self.public_ipv4:
+        if (
+            prev_private_ipv4 != self.private_ipv4
+            or prev_public_ipv4 != self.public_ipv4
+        ):
             self.warn("IP address has changed, you may need to run ‘nixops deploy’")
 
         self.wait_for_ssh(check=True)
         self.send_keys()
-
 
     def _check(self, res):
         if not self.vm_id:
@@ -1502,7 +2011,7 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         self.connect()
         instance = self._get_instance(allow_missing=True)
         old_state = self.state
-        #self.log("instance state is ‘{0}’".format(instance.state if instance else "gone"))
+        # self.log("instance state is ‘{0}’".format(instance.state if instance else "gone"))
 
         if instance is None or instance.state in {"shutting-down", "terminated"}:
             self.state = self.MISSING
@@ -1520,21 +2029,45 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             res.disks_ok = True
             for device_stored, v in self.block_device_mapping.items():
                 device_real = device_name_stored_to_real(device_stored)
-                device_that_boto_expects = device_name_to_boto_expected(device_real) # boto expects only sd names
+                device_that_boto_expects = device_name_to_boto_expected(
+                    device_real
+                )  # boto expects only sd names
 
-                if device_that_boto_expects not in instance.block_device_mapping.keys() and v.get('volumeId', None):
+                if device_that_boto_expects not in instance.block_device_mapping.keys() and v.get(
+                    "volumeId", None
+                ):
                     res.disks_ok = False
-                    res.messages.append("volume ‘{0}’ not attached to ‘{1}’".format(v['volumeId'], device_real))
-                    volume = nixopsaws.ec2_utils.get_volume_by_id(self.connect(), v['volumeId'], allow_missing=True)
+                    res.messages.append(
+                        "volume ‘{0}’ not attached to ‘{1}’".format(
+                            v["volumeId"], device_real
+                        )
+                    )
+                    volume = nixopsaws.ec2_utils.get_volume_by_id(
+                        self.connect(), v["volumeId"], allow_missing=True
+                    )
                     if not volume:
-                        res.messages.append("volume ‘{0}’ no longer exists".format(v['volumeId']))
+                        res.messages.append(
+                            "volume ‘{0}’ no longer exists".format(v["volumeId"])
+                        )
 
-                if device_that_boto_expects in instance.block_device_mapping.keys() and instance.block_device_mapping[device_that_boto_expects].status != 'attached' :
+                if (
+                    device_that_boto_expects in instance.block_device_mapping.keys()
+                    and instance.block_device_mapping[device_that_boto_expects].status
+                    != "attached"
+                ):
                     res.disks_ok = False
-                    res.messages.append("volume ‘{0}’ on device ‘{1}’ has unexpected state: ‘{2}’".format(v['volumeId'], device_real, instance.block_device_mapping[device_stored].status))
+                    res.messages.append(
+                        "volume ‘{0}’ on device ‘{1}’ has unexpected state: ‘{2}’".format(
+                            v["volumeId"],
+                            device_real,
+                            instance.block_device_mapping[device_stored].status,
+                        )
+                    )
 
-
-            if self.private_ipv4 != instance.private_ip_address or self.public_ipv4 != instance.ip_address:
+            if (
+                self.private_ipv4 != instance.private_ip_address
+                or self.public_ipv4 != instance.ip_address
+            ):
                 self.warn("IP address has changed, you may need to run ‘nixops deploy’")
                 self.private_ipv4 = instance.private_ip_address
                 self.public_ipv4 = instance.ip_address
@@ -1556,8 +2089,9 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                 for e in ist.events:
                     res.messages.append("Event ‘{0}’:".format(e.code))
                     res.messages.append("  * {0}".format(e.description))
-                    res.messages.append("  * {0} - {1}".format(e.not_before, e.not_after))
-
+                    res.messages.append(
+                        "  * {0} - {1}".format(e.not_before, e.not_after)
+                    )
 
     def reboot(self, hard=False):
         self.log("rebooting EC2 machine...")
@@ -1565,13 +2099,15 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         instance.reboot()
         self.state = self.STARTING
 
-
     def get_console_output(self):
         if not self.vm_id:
-            raise Exception("cannot get console output of non-existant machine ‘{0}’".format(self.name))
+            raise Exception(
+                "cannot get console output of non-existant machine ‘{0}’".format(
+                    self.name
+                )
+            )
         self.connect()
         return self._conn.get_console_output(self.vm_id).output or "(not available)"
-
 
     def next_charge_time(self):
         if not self.start_time:

--- a/nixopsaws/ec2_utils.py
+++ b/nixopsaws/ec2_utils.py
@@ -17,6 +17,7 @@ from boto.pyami.config import Config
 
 import botocore
 
+
 def fetch_aws_secret_key(access_key_id):
     """
         Fetch the secret access key corresponding to the given access key ID from ~/.ec2-keys,
@@ -26,72 +27,102 @@ def fetch_aws_secret_key(access_key_id):
     def parse_ec2_keys():
         path = os.path.expanduser("~/.ec2-keys")
         if os.path.isfile(path):
-            with open(path, 'r') as f:
+            with open(path, "r") as f:
                 contents = f.read()
                 for l in contents.splitlines():
-                    l = l.split("#")[0] # drop comments
+                    l = l.split("#")[0]  # drop comments
                     w = l.split()
-                    if len(w) < 2 or len(w) > 3: continue
-                    if len(w) == 3 and w[2] == access_key_id: return (w[0], w[1])
-                    if w[0] == access_key_id: return (access_key_id, w[1])
+                    if len(w) < 2 or len(w) > 3:
+                        continue
+                    if len(w) == 3 and w[2] == access_key_id:
+                        return (w[0], w[1])
+                    if w[0] == access_key_id:
+                        return (access_key_id, w[1])
         return None
 
     def parse_aws_credentials():
-        path = os.getenv('AWS_SHARED_CREDENTIALS_FILE', "~/.aws/credentials")
+        path = os.getenv("AWS_SHARED_CREDENTIALS_FILE", "~/.aws/credentials")
         if not os.path.exists(os.path.expanduser(path)):
             return None
 
         conf = Config(os.path.expanduser(path))
 
-        if access_key_id == conf.get('default', 'aws_access_key_id'):
-            return (access_key_id, conf.get('default', 'aws_secret_access_key'))
-        return (conf.get(access_key_id, 'aws_access_key_id'),
-                conf.get(access_key_id, 'aws_secret_access_key'))
+        if access_key_id == conf.get("default", "aws_access_key_id"):
+            return (access_key_id, conf.get("default", "aws_secret_access_key"))
+        return (
+            conf.get(access_key_id, "aws_access_key_id"),
+            conf.get(access_key_id, "aws_secret_access_key"),
+        )
 
     def ec2_keys_from_env():
-        return (access_key_id,
-                os.environ.get('EC2_SECRET_KEY') or os.environ.get('AWS_SECRET_ACCESS_KEY'))
+        return (
+            access_key_id,
+            os.environ.get("EC2_SECRET_KEY") or os.environ.get("AWS_SECRET_ACCESS_KEY"),
+        )
 
-    sources = (get_credentials() for get_credentials in
-                [parse_ec2_keys, parse_aws_credentials, ec2_keys_from_env])
+    sources = (
+        get_credentials()
+        for get_credentials in [
+            parse_ec2_keys,
+            parse_aws_credentials,
+            ec2_keys_from_env,
+        ]
+    )
     # Get the first existing access-secret key pair
-    credentials = next( (keys for keys in sources if keys and keys[1]), None)
+    credentials = next((keys for keys in sources if keys and keys[1]), None)
 
     if not credentials:
-        raise Exception("please set $EC2_SECRET_KEY or $AWS_SECRET_ACCESS_KEY, or add the key for ‘{0}’ to ~/.ec2-keys or ~/.aws/credentials"
-                        .format(access_key_id))
+        raise Exception(
+            "please set $EC2_SECRET_KEY or $AWS_SECRET_ACCESS_KEY, or add the key for ‘{0}’ to ~/.ec2-keys or ~/.aws/credentials".format(
+                access_key_id
+            )
+        )
 
     return credentials
+
 
 def connect(region, access_key_id):
     """Connect to the specified EC2 region using the given access key."""
     assert region
     (access_key_id, secret_access_key) = fetch_aws_secret_key(access_key_id)
     conn = boto.ec2.connect_to_region(
-        region_name=region, aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
+        region_name=region,
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key=secret_access_key,
+    )
     if not conn:
         raise Exception("invalid EC2 region ‘{0}’".format(region))
     return conn
 
+
 def connect_ec2_boto3(region, access_key_id):
     assert region
     (access_key_id, secret_access_key) = fetch_aws_secret_key(access_key_id)
-    client = boto3.session.Session().client('ec2', region_name=region, aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
+    client = boto3.session.Session().client(
+        "ec2",
+        region_name=region,
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key=secret_access_key,
+    )
     return client
+
 
 def connect_vpc(region, access_key_id):
     """Connect to the specified VPC region using the given access key."""
     assert region
     (access_key_id, secret_access_key) = fetch_aws_secret_key(access_key_id)
     conn = boto.vpc.connect_to_region(
-        region_name=region, aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
+        region_name=region,
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key=secret_access_key,
+    )
     if not conn:
         raise Exception("invalid VPC region ‘{0}’".format(region))
     return conn
 
 
 def get_access_key_id():
-    return os.environ.get('EC2_ACCESS_KEY') or os.environ.get('AWS_ACCESS_KEY_ID')
+    return os.environ.get("EC2_ACCESS_KEY") or os.environ.get("AWS_ACCESS_KEY_ID")
 
 
 def retry(f, error_codes=[], logger=None):
@@ -101,24 +132,32 @@ def retry(f, error_codes=[], logger=None):
     """
 
     def handle_exception(e):
-        if hasattr(e, 'error_code'):
+        if hasattr(e, "error_code"):
             err_code = e.error_code
             err_msg = e.error_message
         else:
-            err_code = e.response['Error']['Code']
-            err_msg = e.response['Error']['Message']
+            err_code = e.response["Error"]["Code"]
+            err_msg = e.response["Error"]["Message"]
 
         if i == num_retries or (error_codes != [] and not err_code in error_codes):
             raise e
         if logger is not None:
-            logger.log("got (possibly transient) EC2 error code '{0}': {1}. retrying...".format(err_code, err_msg))
+            logger.log(
+                "got (possibly transient) EC2 error code '{0}': {1}. retrying...".format(
+                    err_code, err_msg
+                )
+            )
 
     def handle_boto3_exception(e):
         if i == num_retries:
             raise e
         if logger is not None:
-            if hasattr(e, 'response'):
-                logger.log("got (possibly transient) EC2 error '{}', retrying...".format(str(e.response['Error'])))
+            if hasattr(e, "response"):
+                logger.log(
+                    "got (possibly transient) EC2 error '{}', retrying...".format(
+                        str(e.response["Error"])
+                    )
+                )
 
     i = 0
     num_retries = 7
@@ -155,14 +194,17 @@ def get_volume_by_id(conn, volume_id, allow_missing=False):
             raise Exception("unable to find volume ‘{0}’".format(volume_id))
         return volumes[0]
     except boto.exception.EC2ResponseError as e:
-        if e.error_code != "InvalidVolume.NotFound": raise
+        if e.error_code != "InvalidVolume.NotFound":
+            raise
     return None
 
 
-def wait_for_volume_available(conn, volume_id, logger, states=['available']):
+def wait_for_volume_available(conn, volume_id, logger, states=["available"]):
     """Wait for an EBS volume to become available."""
 
-    logger.log_start("waiting for volume ‘{0}’ to become available... ".format(volume_id))
+    logger.log_start(
+        "waiting for volume ‘{0}’ to become available... ".format(volume_id)
+    )
 
     def check_available():
         # Allow volume to be missing due to eventual consistency.
@@ -172,25 +214,34 @@ def wait_for_volume_available(conn, volume_id, logger, states=['available']):
 
     nixops.util.check_wait(check_available, max_tries=90)
 
-    logger.log_end('')
+    logger.log_end("")
 
 
 def name_to_security_group(conn, name, vpc_id):
-    if not vpc_id or name.startswith('sg-'):
+    if not vpc_id or name.startswith("sg-"):
         return name
 
     id = None
-    for sg in conn.get_all_security_groups(filters={'group-name':name, 'vpc-id': vpc_id}):
+    for sg in conn.get_all_security_groups(
+        filters={"group-name": name, "vpc-id": vpc_id}
+    ):
         if sg.name == name:
             id = sg.id
             return id
 
-    raise Exception("could not resolve security group name '{0}' in VPC '{1}'".format(name, vpc_id))
+    raise Exception(
+        "could not resolve security group name '{0}' in VPC '{1}'".format(name, vpc_id)
+    )
+
 
 def id_to_security_group_name(conn, sg_id, vpc_id):
     name = None
-    for sg in conn.get_all_security_groups(filters={'group-id':sg_id, 'vpc-id': vpc_id}):
+    for sg in conn.get_all_security_groups(
+        filters={"group-id": sg_id, "vpc-id": vpc_id}
+    ):
         if sg.id == sg_id:
             name = sg.name
             return name
-    raise Exception("could not resolve security group id '{0}' in VPC '{1}'".format(sg_id, vpc_id))
+    raise Exception(
+        "could not resolve security group id '{0}' in VPC '{1}'".format(sg_id, vpc_id)
+    )

--- a/nixopsaws/plugin.py
+++ b/nixopsaws/plugin.py
@@ -1,23 +1,26 @@
-
 import os.path
 import nixops.plugins
 
+
 @nixops.plugins.hookimpl
 def nixexprs():
-    expr_path = os.path.realpath(os.path.dirname(__file__) + "/../../../../share/nix/nixops-aws")
+    expr_path = os.path.realpath(
+        os.path.dirname(__file__) + "/../../../../share/nix/nixops-aws"
+    )
     if not os.path.exists(expr_path):
-        expr_path = os.path.realpath(os.path.dirname(__file__) + "/../../../../../share/nix/nixops-aws")
+        expr_path = os.path.realpath(
+            os.path.dirname(__file__) + "/../../../../../share/nix/nixops-aws"
+        )
     if not os.path.exists(expr_path):
         expr_path = os.path.dirname(__file__) + "/../nix"
 
-    return [
-        expr_path
-    ]
+    return [expr_path]
+
 
 @nixops.plugins.hookimpl
 def load():
     return [
         "nixopsaws.resources",
         "nixopsaws.backends.ec2",
-        "nixopsaws.resources.ec2_keypair"
+        "nixopsaws.resources.ec2_keypair",
     ]

--- a/nixopsaws/resources/aws_vpn_connection.py
+++ b/nixopsaws/resources/aws_vpn_connection.py
@@ -7,6 +7,7 @@ import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState
 import nixopsaws.ec2_utils
 
+
 class AWSVPNConnectionDefinition(nixops.resources.ResourceDefinition):
     """Definition of an AWS VPN connection."""
 
@@ -21,17 +22,28 @@ class AWSVPNConnectionDefinition(nixops.resources.ResourceDefinition):
     def show_type(self):
         return "{0}".format(self.get_type())
 
+
 class AWSVPNConnectionState(nixops.resources.DiffEngineResourceState, EC2CommonState):
     """State of a AWS VPN gateway."""
-    state = nixops.util.attr_property("state", nixops.resources.DiffEngineResourceState.MISSING, int)
+
+    state = nixops.util.attr_property(
+        "state", nixops.resources.DiffEngineResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("accessKeyId", None)
     _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ["vpnConnectionId"]
 
     def __init__(self, depl, name, id):
         nixops.resources.DiffEngineResourceState.__init__(self, depl, name, id)
         self._state = StateDict(depl, id)
-        self.handle_create_vpn_conn = Handler(['region', 'vpnGatewayId', 'customerGatewayId', 'staticRoutesOnly'], handle=self.realize_create_vpn_conn)
-        self.handle_tag_update = Handler(['tags'], after=[self.handle_create_vpn_conn], handle=self.realize_update_tag)
+        self.handle_create_vpn_conn = Handler(
+            ["region", "vpnGatewayId", "customerGatewayId", "staticRoutesOnly"],
+            handle=self.realize_create_vpn_conn,
+        )
+        self.handle_tag_update = Handler(
+            ["tags"],
+            after=[self.handle_create_vpn_conn],
+            handle=self.realize_update_tag,
+        )
 
     @classmethod
     def get_type(cls):
@@ -39,87 +51,113 @@ class AWSVPNConnectionState(nixops.resources.DiffEngineResourceState, EC2CommonS
 
     def show_type(self):
         s = super(AWSVPNConnectionState, self).show_type()
-        if self._state.get('region', None): s = "{0} [{1}]".format(s, self._state['region'])
+        if self._state.get("region", None):
+            s = "{0} [{1}]".format(s, self._state["region"])
         return s
 
     @property
     def resource_id(self):
-        return self._state.get('vpnConnectionId', None)
+        return self._state.get("vpnConnectionId", None)
 
     def prefix_definition(self, attr):
-        return {('resources', 'awsVPNConnections'): attr}
+        return {("resources", "awsVPNConnections"): attr}
 
     def get_defintion_prefix(self):
         return "resources.awsVPNConnections."
 
     def create_after(self, resources, defn):
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.vpc_customer_gateway.VPCCustomerGatewayState) or
-                isinstance(r, nixopsaws.resources.aws_vpn_gateway.AWSVPNGatewayState)}
+        return {
+            r
+            for r in resources
+            if isinstance(
+                r, nixopsaws.resources.vpc_customer_gateway.VPCCustomerGatewayState
+            )
+            or isinstance(r, nixopsaws.resources.aws_vpn_gateway.AWSVPNGatewayState)
+        }
 
     def realize_create_vpn_conn(self, allow_recreate):
-       config = self.get_defn()
+        config = self.get_defn()
 
-       if self.state == self.UP:
+        if self.state == self.UP:
             if not allow_recreate:
-                raise Exception("vpn connection {} definition changed and it needs to be recreated"
-                                " use --allow-recreate if you want to create a new one".format(self._state['vpnConnectionId']))
+                raise Exception(
+                    "vpn connection {} definition changed and it needs to be recreated"
+                    " use --allow-recreate if you want to create a new one".format(
+                        self._state["vpnConnectionId"]
+                    )
+                )
             self.warn("vpn connection definition changed, recreating ...")
             self._destroy()
 
-       self._state['region'] = config['region']
-       customer_gtw_id = config['customerGatewayId']
-       if customer_gtw_id.startswith("res-"):
-           res = self.depl.get_typed_resource(customer_gtw_id[4:].split(".")[0], "vpc-customer-gateway")
-           customer_gtw_id = res._state['customerGatewayId']
+        self._state["region"] = config["region"]
+        customer_gtw_id = config["customerGatewayId"]
+        if customer_gtw_id.startswith("res-"):
+            res = self.depl.get_typed_resource(
+                customer_gtw_id[4:].split(".")[0], "vpc-customer-gateway"
+            )
+            customer_gtw_id = res._state["customerGatewayId"]
 
-       vpn_gateway_id = config['vpnGatewayId']
-       if vpn_gateway_id.startswith("res-"):
-           res = self.depl.get_typed_resource(vpn_gateway_id[4:].split(".")[0], "aws-vpn-gateway")
-           vpn_gateway_id = res._state['vpnGatewayId']
+        vpn_gateway_id = config["vpnGatewayId"]
+        if vpn_gateway_id.startswith("res-"):
+            res = self.depl.get_typed_resource(
+                vpn_gateway_id[4:].split(".")[0], "aws-vpn-gateway"
+            )
+            vpn_gateway_id = res._state["vpnGatewayId"]
 
-       self.log("creating vpn connection between customer gateway {0} and vpn gateway {1}".format(customer_gtw_id, vpn_gateway_id))
-       vpn_connection = self.get_client().create_vpn_connection(
+        self.log(
+            "creating vpn connection between customer gateway {0} and vpn gateway {1}".format(
+                customer_gtw_id, vpn_gateway_id
+            )
+        )
+        vpn_connection = self.get_client().create_vpn_connection(
             CustomerGatewayId=customer_gtw_id,
             VpnGatewayId=vpn_gateway_id,
             Type="ipsec.1",
-            Options={
-                'StaticRoutesOnly': config['staticRoutesOnly']
-                }
-            )
+            Options={"StaticRoutesOnly": config["staticRoutesOnly"]},
+        )
 
-       vpn_conn_id = vpn_connection['VpnConnection']['VpnConnectionId']
-       with self.depl._db:
-           self.state = self.UP
-           self._state['vpnConnectionId'] = vpn_conn_id
-           self._state['vpnGatewayId'] = vpn_gateway_id
-           self._state['customerGatewayId'] = customer_gtw_id
-           self._state['staticRoutesOnly'] = config['staticRoutesOnly']
+        vpn_conn_id = vpn_connection["VpnConnection"]["VpnConnectionId"]
+        with self.depl._db:
+            self.state = self.UP
+            self._state["vpnConnectionId"] = vpn_conn_id
+            self._state["vpnGatewayId"] = vpn_gateway_id
+            self._state["customerGatewayId"] = customer_gtw_id
+            self._state["staticRoutesOnly"] = config["staticRoutesOnly"]
 
     def realize_update_tag(self, allow_recreate):
         config = self.get_defn()
-        tags = config['tags']
+        tags = config["tags"]
         tags.update(self.get_common_tags())
-        self.get_client().create_tags(Resources=[self._state['vpnConnectionId']], Tags=[{"Key": k, "Value": tags[k]} for k in tags])
+        self.get_client().create_tags(
+            Resources=[self._state["vpnConnectionId"]],
+            Tags=[{"Key": k, "Value": tags[k]} for k in tags],
+        )
 
     def _destroy(self):
         if self.state == self.UP:
-            self.log("deleting vpn connection {}".format(self._state['vpnConnectionId']))
+            self.log(
+                "deleting vpn connection {}".format(self._state["vpnConnectionId"])
+            )
             try:
                 self.get_client().delete_vpn_connection(
-                    VpnConnectionId=self._state['vpnConnectionId'])
+                    VpnConnectionId=self._state["vpnConnectionId"]
+                )
             except botocore.exceptions.ClientError as e:
-                if e.response['Error']['Code'] == "InvalidVpnConnectionID.NotFound":
-                    self.warn("vpn connection {} was already deleted".format(self._state['vpnConnectionId']))
+                if e.response["Error"]["Code"] == "InvalidVpnConnectionID.NotFound":
+                    self.warn(
+                        "vpn connection {} was already deleted".format(
+                            self._state["vpnConnectionId"]
+                        )
+                    )
                 else:
                     raise e
 
         with self.depl._db:
             self.state = self.MISSING
-            self._state['vpnConnectionId'] = None
-            self._state['vpnGatewayId'] = None
-            self._state['customerGatewayId'] = None
-            self._state['staticRoutesOnly'] = None
+            self._state["vpnConnectionId"] = None
+            self._state["vpnGatewayId"] = None
+            self._state["customerGatewayId"] = None
+            self._state["staticRoutesOnly"] = None
 
     def destroy(self, wipe=True):
         self._destroy()

--- a/nixopsaws/resources/aws_vpn_connection_route.py
+++ b/nixopsaws/resources/aws_vpn_connection_route.py
@@ -9,6 +9,7 @@ import nixopsaws.ec2_utils
 from nixops.diff import Diff, Handler
 from nixops.state import StateDict
 
+
 class AWSVPNConnectionRouteDefinition(nixops.resources.ResourceDefinition):
     """Definition of a VPN connection route"""
 
@@ -23,10 +24,13 @@ class AWSVPNConnectionRouteDefinition(nixops.resources.ResourceDefinition):
     def show_type(self):
         return "{0}".format(self.get_type())
 
+
 class AWSVPNConnectionState(nixops.resources.DiffEngineResourceState, EC2CommonState):
     """State of a VPN connection route"""
 
-    state = nixops.util.attr_property("state", nixops.resources.DiffEngineResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.DiffEngineResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("accessKeyId", None)
     _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED
 
@@ -37,71 +41,96 @@ class AWSVPNConnectionState(nixops.resources.DiffEngineResourceState, EC2CommonS
     def __init__(self, depl, name, id):
         nixops.resources.DiffEngineResourceState.__init__(self, depl, name, id)
         self._state = StateDict(depl, id)
-        self.region = self._state.get('region', None)
-        self.handle_create_vpn_route = Handler(['region', 'vpnConnectionId', 'destinationCidrBlock'], handle=self.realize_create_vpn_route)
+        self.region = self._state.get("region", None)
+        self.handle_create_vpn_route = Handler(
+            ["region", "vpnConnectionId", "destinationCidrBlock"],
+            handle=self.realize_create_vpn_route,
+        )
 
     def show_type(self):
         s = super(AWSVPNConnectionState, self).show_type()
-        if self.region: s = "{0} [{1}]".format(s, self.region)
+        if self.region:
+            s = "{0} [{1}]".format(s, self.region)
         return s
 
     @property
     def resource_id(self):
-        return self._state.get('destinationCidrBlock', None)
+        return self._state.get("destinationCidrBlock", None)
 
     def prefix_definition(self, attr):
-        return {('resources', 'awsVPNConnectionRoutes'): attr}
+        return {("resources", "awsVPNConnectionRoutes"): attr}
 
     def get_definition_prefix(self):
         return "resources.awsVPNConnectionRoutes."
 
     def create_after(self, resources, defn):
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.aws_vpn_connection.AWSVPNConnectionState)}
+        return {
+            r
+            for r in resources
+            if isinstance(
+                r, nixopsaws.resources.aws_vpn_connection.AWSVPNConnectionState
+            )
+        }
 
     def realize_create_vpn_route(self, allow_recreate):
         config = self.get_defn()
 
         if self.state == self.UP:
             if not allow_recreate:
-                raise Exception("vpn connection route {} definition changed and it needs to be recreated"
-                                " use --allow-recreate if you want to create a new one".format(self.name))
+                raise Exception(
+                    "vpn connection route {} definition changed and it needs to be recreated"
+                    " use --allow-recreate if you want to create a new one".format(
+                        self.name
+                    )
+                )
             self.warn("route definition changed, recreating ...")
             self._destroy()
 
-        self._state['region'] = config['region']
-        vpn_conn_id = config['vpnConnectionId']
+        self._state["region"] = config["region"]
+        vpn_conn_id = config["vpnConnectionId"]
         if vpn_conn_id.startswith("res-"):
-            res = self.depl.get_typed_resource(vpn_conn_id[4:].split(".")[0], "aws-vpn-connection")
-            vpn_conn_id = res._state['vpnConnectionId']
+            res = self.depl.get_typed_resource(
+                vpn_conn_id[4:].split(".")[0], "aws-vpn-connection"
+            )
+            vpn_conn_id = res._state["vpnConnectionId"]
 
-        self.log("creating route to {0} using vpn connection {1}".format(config['destinationCidrBlock'], vpn_conn_id))
+        self.log(
+            "creating route to {0} using vpn connection {1}".format(
+                config["destinationCidrBlock"], vpn_conn_id
+            )
+        )
         self.get_client().create_vpn_connection_route(
-            DestinationCidrBlock=config['destinationCidrBlock'],
-            VpnConnectionId=vpn_conn_id)
+            DestinationCidrBlock=config["destinationCidrBlock"],
+            VpnConnectionId=vpn_conn_id,
+        )
 
         with self.depl._db:
             self.state = self.UP
-            self._state['vpnConnectionId'] = vpn_conn_id
-            self._state['destinationCidrBlock'] = config['destinationCidrBlock']
+            self._state["vpnConnectionId"] = vpn_conn_id
+            self._state["destinationCidrBlock"] = config["destinationCidrBlock"]
 
     def _destroy(self):
-        if self.state != self.UP: return
-        self.log("deleting route to {}".format(self._state['destinationCidrBlock']))
+        if self.state != self.UP:
+            return
+        self.log("deleting route to {}".format(self._state["destinationCidrBlock"]))
         try:
             self.get_client().delete_vpn_connection_route(
-                DestinationCidrBlock=self._state['destinationCidrBlock'],
-                VpnConnectionId=self._state['vpnConnectionId'])
+                DestinationCidrBlock=self._state["destinationCidrBlock"],
+                VpnConnectionId=self._state["vpnConnectionId"],
+            )
         except botocore.exceptions.ClientError as e:
-            if e.response['Error']['Code'] == "InvalidRoute.NotFound" or e.response['Error']['Code'] == "InvalidVpnConnectionID.NotFound":
+            if (
+                e.response["Error"]["Code"] == "InvalidRoute.NotFound"
+                or e.response["Error"]["Code"] == "InvalidVpnConnectionID.NotFound"
+            ):
                 self.warn("route or vpn connection was already deleted")
             else:
                 raise e
 
         with self.depl._db:
             self.state = self.MISSING
-            self._state['vpnConnectionId'] = None
-            self._state['destinationCidrBlock'] = None
+            self._state["vpnConnectionId"] = None
+            self._state["destinationCidrBlock"] = None
 
     def destroy(self, wipe=True):
         self._destroy()

--- a/nixopsaws/resources/aws_vpn_gateway.py
+++ b/nixopsaws/resources/aws_vpn_gateway.py
@@ -7,6 +7,7 @@ import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState
 import nixopsaws.ec2_utils
 
+
 class AWSVPNGatewayDefinition(nixops.resources.ResourceDefinition):
     """Definition of an AWS VPN gateway."""
 
@@ -21,17 +22,25 @@ class AWSVPNGatewayDefinition(nixops.resources.ResourceDefinition):
     def show_type(self):
         return "{0}".format(self.get_type())
 
+
 class AWSVPNGatewayState(nixops.resources.DiffEngineResourceState, EC2CommonState):
     """State of a AWS VPN gateway."""
-    state = nixops.util.attr_property("state", nixops.resources.DiffEngineResourceState.MISSING, int)
+
+    state = nixops.util.attr_property(
+        "state", nixops.resources.DiffEngineResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("accessKeyId", None)
     _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ["vpnGatewayId"]
 
     def __init__(self, depl, name, id):
         nixops.resources.DiffEngineResourceState.__init__(self, depl, name, id)
         self._state = StateDict(depl, id)
-        self.handle_create_vpn_gtw = Handler(['region', 'zone', 'vpcId'], handle=self.realize_create_vpn_gtw)
-        self.handle_tag_update = Handler(['tags'], after=[self.handle_create_vpn_gtw], handle=self.realize_update_tag)
+        self.handle_create_vpn_gtw = Handler(
+            ["region", "zone", "vpcId"], handle=self.realize_create_vpn_gtw
+        )
+        self.handle_tag_update = Handler(
+            ["tags"], after=[self.handle_create_vpn_gtw], handle=self.realize_update_tag
+        )
 
     @classmethod
     def get_type(cls):
@@ -39,95 +48,112 @@ class AWSVPNGatewayState(nixops.resources.DiffEngineResourceState, EC2CommonStat
 
     def show_type(self):
         s = super(AWSVPNGatewayState, self).show_type()
-        if self._state.get('region', None): s = "{0} [{1}]".format(s, self._state['region'])
+        if self._state.get("region", None):
+            s = "{0} [{1}]".format(s, self._state["region"])
         return s
 
     @property
     def resource_id(self):
-        return self._state.get('vpnGatewayId', None)
+        return self._state.get("vpnGatewayId", None)
 
     def prefix_definition(self, attr):
-        return {('resources', 'awsVPNGateways'): attr}
+        return {("resources", "awsVPNGateways"): attr}
 
     def get_defintion_prefix(self):
         return "resources.awsVPNGateways."
 
     def create_after(self, resources, defn):
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.vpc.VPCState)}
+        return {r for r in resources if isinstance(r, nixopsaws.resources.vpc.VPCState)}
 
     def realize_create_vpn_gtw(self, allow_recreate):
         config = self.get_defn()
 
         if self.state == self.UP:
             if not allow_recreate:
-                raise Exception("VPN gateway {} defintion changed"
-                                " use --allow-recreate if you want to create a new one".format(
-                                    self._state['vpnGatewayId']))
+                raise Exception(
+                    "VPN gateway {} defintion changed"
+                    " use --allow-recreate if you want to create a new one".format(
+                        self._state["vpnGatewayId"]
+                    )
+                )
             self.warn("VPN gateway changed, recreating...")
             self._destroy()
 
-        self._state['region'] = config['region']
-        vpc_id = config['vpcId']
+        self._state["region"] = config["region"]
+        vpc_id = config["vpcId"]
         if vpc_id.startswith("res-"):
             res = self.depl.get_typed_resource(vpc_id[4:].split(".")[0], "vpc")
-            vpc_id = res._state['vpcId']
+            vpc_id = res._state["vpcId"]
 
-        self.log("creating VPN gateway in zone {}".format(config['zone']))
+        self.log("creating VPN gateway in zone {}".format(config["zone"]))
         response = self.get_client().create_vpn_gateway(
-            AvailabilityZone=config['zone'],
-            Type="ipsec.1")
+            AvailabilityZone=config["zone"], Type="ipsec.1"
+        )
 
-        vpn_gtw_id = response['VpnGateway']['VpnGatewayId']
+        vpn_gtw_id = response["VpnGateway"]["VpnGatewayId"]
         self.log("attaching vpn gateway {0} to vpc {1}".format(vpn_gtw_id, vpc_id))
-        self.get_client().attach_vpn_gateway(
-            VpcId=vpc_id,
-            VpnGatewayId=vpn_gtw_id)
-        #TODO wait for the attchement state
+        self.get_client().attach_vpn_gateway(VpcId=vpc_id, VpnGatewayId=vpn_gtw_id)
+        # TODO wait for the attchement state
 
         with self.depl._db:
             self.state = self.UP
-            self._state['vpnGatewayId'] = vpn_gtw_id
-            self._state['vpcId'] = vpc_id
-            self._state['zone'] = config['zone']
+            self._state["vpnGatewayId"] = vpn_gtw_id
+            self._state["vpcId"] = vpc_id
+            self._state["zone"] = config["zone"]
 
     def realize_update_tag(self, allow_recreate):
         config = self.get_defn()
-        tags = config['tags']
+        tags = config["tags"]
         tags.update(self.get_common_tags())
-        self.get_client().create_tags(Resources=[self._state['vpnGatewayId']], Tags=[{"Key": k, "Value": tags[k]} for k in tags])
+        self.get_client().create_tags(
+            Resources=[self._state["vpnGatewayId"]],
+            Tags=[{"Key": k, "Value": tags[k]} for k in tags],
+        )
 
     def _destroy(self):
-        if self.state != self.UP: return
-        self.log("detaching vpn gateway {0} from vpc {1}".format(self._state['vpnGatewayId'], self._state['vpcId']))
+        if self.state != self.UP:
+            return
+        self.log(
+            "detaching vpn gateway {0} from vpc {1}".format(
+                self._state["vpnGatewayId"], self._state["vpcId"]
+            )
+        )
         try:
             self.get_client().detach_vpn_gateway(
-                VpcId=self._state['vpcId'],
-                VpnGatewayId=self._state['vpnGatewayId'])
+                VpcId=self._state["vpcId"], VpnGatewayId=self._state["vpnGatewayId"]
+            )
         except botocore.exceptions.ClientError as e:
-            if e.response['Error']['Code'] == "InvalidVpnGatewayAttachment.NotFound":
-                self.warn("VPN gateway '{0}' attachment with VPC '{1}' is invalid".format(
-                    self._state['vpnGatewayId'], self._state['vpcId']))
+            if e.response["Error"]["Code"] == "InvalidVpnGatewayAttachment.NotFound":
+                self.warn(
+                    "VPN gateway '{0}' attachment with VPC '{1}' is invalid".format(
+                        self._state["vpnGatewayId"], self._state["vpcId"]
+                    )
+                )
             else:
                 raise e
 
         # TODO delete VPN connections associated with this VPN gtw
-        self.log("deleting vpn gateway {}".format(self._state['vpnGatewayId']))
+        self.log("deleting vpn gateway {}".format(self._state["vpnGatewayId"]))
         try:
             self.get_client().delete_vpn_gateway(
-                VpnGatewayId=self._state['vpnGatewayId'])
+                VpnGatewayId=self._state["vpnGatewayId"]
+            )
         except botocore.exceptions.ClientError as e:
-            if e.response['Error']['Code'] == "InvalidVpnGatewayID.NotFound":
-                self.warn("VPN gateway {} was already deleted".format(self._state['vpnGatewayId']))
+            if e.response["Error"]["Code"] == "InvalidVpnGatewayID.NotFound":
+                self.warn(
+                    "VPN gateway {} was already deleted".format(
+                        self._state["vpnGatewayId"]
+                    )
+                )
             else:
                 raise e
 
         with self.depl._db:
             self.state = self.MISSING
-            self._state['region'] = None
-            self._state['vpnGatewayId'] = None
-            self._state['vpcId'] = None
-            self._state['zone'] = None
+            self._state["region"] = None
+            self._state["vpnGatewayId"] = None
+            self._state["vpcId"] = None
+            self._state["zone"] = None
 
     def destroy(self, wipe=False):
         self._destroy()

--- a/nixopsaws/resources/cloudwatch_log_group.py
+++ b/nixopsaws/resources/cloudwatch_log_group.py
@@ -8,6 +8,7 @@ import nixops.util
 import nixops.resources
 import nixopsaws.ec2_utils
 
+
 class CloudWatchLogGroupDefinition(nixops.resources.ResourceDefinition):
     """Definition of a cloudwatch log group."""
 
@@ -22,13 +23,19 @@ class CloudWatchLogGroupDefinition(nixops.resources.ResourceDefinition):
     def show_type(self):
         return "{0}".format(self.get_type())
 
+
 class CloudWatchLogGroupState(nixops.resources.ResourceState):
     """State of the cloudwatch log group"""
-    state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+
+    state = nixops.util.attr_property(
+        "state", nixops.resources.ResourceState.MISSING, int
+    )
     log_group_name = nixops.util.attr_property("cloudwatch.logGroupName", None)
     region = nixops.util.attr_property("cloudwatch.region", None)
     access_key_id = nixops.util.attr_property("cloudwatch.accessKeyId", None)
-    retention_in_days = nixops.util.attr_property("cloudwatch.logGroupRetentionInDays", None, int)
+    retention_in_days = nixops.util.attr_property(
+        "cloudwatch.logGroupRetentionInDays", None, int
+    )
     arn = nixops.util.attr_property("cloudwatch.logGroupARN", None)
 
     @classmethod
@@ -41,7 +48,8 @@ class CloudWatchLogGroupState(nixops.resources.ResourceState):
 
     def show_type(self):
         s = super(CloudWatchLogGroupState, self).show_type()
-        if self.region: s = "{0} [{1}]".format(s, self.region)
+        if self.region:
+            s = "{0} [{1}]".format(s, self.region)
         return s
 
     @property
@@ -49,29 +57,38 @@ class CloudWatchLogGroupState(nixops.resources.ResourceState):
         return self.log_group_name
 
     def prefix_definition(self, attr):
-        return {('resources', 'cloudwatchLogGroups'): attr}
+        return {("resources", "cloudwatchLogGroups"): attr}
 
     def get_physical_spec(self):
-        return {'arn': self.arn}
+        return {"arn": self.arn}
 
     def get_definition_prefix(self):
         return "resources.cloudwatchLogGroups."
 
     def connect(self):
-        if self._conn: return
+        if self._conn:
+            return
         assert self.region
-        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(self.access_key_id)
+        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(
+            self.access_key_id
+        )
         self._conn = boto.logs.connect_to_region(
-            region_name=self.region, aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
+            region_name=self.region,
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+        )
 
     def _destroy(self):
-        if self.state != self.UP: return
+        if self.state != self.UP:
+            return
         self.connect()
         self.log("destroying cloudwatch log group ‘{0}’...".format(self.log_group_name))
         try:
-         self._conn.delete_log_group(self.log_group_name)
-        except  boto.logs.exceptions.ResourceNotFoundException, e:
-            self.log("the log group ‘{0}’ was already deleted".format(self.log_group_name))
+            self._conn.delete_log_group(self.log_group_name)
+        except boto.logs.exceptions.ResourceNotFoundException, e:
+            self.log(
+                "the log group ‘{0}’ was already deleted".format(self.log_group_name)
+            )
         with self.depl._db:
             self.state = self.MISSING
             self.log_group_name = None
@@ -81,45 +98,70 @@ class CloudWatchLogGroupState(nixops.resources.ResourceState):
 
     def lookup_cloudwatch_log_group(self, log_group_name, next_token=None):
         if log_group_name:
-         response = self._conn.describe_log_groups(log_group_name_prefix=log_group_name,next_token=next_token)
-         if 'logGroups' in response:
-          for log in response['logGroups']:
-              if log_group_name == log['logGroupName']:
-                  return True, log['arn']
-         if 'nextToken' in response:
-             self.lookup_cloudwatch_log_group(log_group_name_prefix=log_group_name,next_token=response['nextToken'])
+            response = self._conn.describe_log_groups(
+                log_group_name_prefix=log_group_name, next_token=next_token
+            )
+            if "logGroups" in response:
+                for log in response["logGroups"]:
+                    if log_group_name == log["logGroupName"]:
+                        return True, log["arn"]
+            if "nextToken" in response:
+                self.lookup_cloudwatch_log_group(
+                    log_group_name_prefix=log_group_name,
+                    next_token=response["nextToken"],
+                )
         return False, None
 
     def create(self, defn, check, allow_reboot, allow_recreate):
-        self.access_key_id = defn.config['accessKeyId'] or nixopsaws.ec2_utils.get_access_key_id()
+        self.access_key_id = (
+            defn.config["accessKeyId"] or nixopsaws.ec2_utils.get_access_key_id()
+        )
         if not self.access_key_id:
-            raise Exception("please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID")
+            raise Exception(
+                "please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID"
+            )
 
-        if self.state == self.UP and (self.log_group_name != defn.config['name'] or self.region != defn.config['region']):
+        if self.state == self.UP and (
+            self.log_group_name != defn.config["name"]
+            or self.region != defn.config["region"]
+        ):
             self.log("cloudwatch log group definition changed, recreating...")
             self._destroy()
             self._conn = None
 
-        self.region = defn.config['region']
+        self.region = defn.config["region"]
         self.connect()
-        exist, arn = self.lookup_cloudwatch_log_group(log_group_name=self.log_group_name)
+        exist, arn = self.lookup_cloudwatch_log_group(
+            log_group_name=self.log_group_name
+        )
 
         if self.arn == None or not exist:
             self.retention_in_days = None
-            self.log("creating cloudwatch log group ‘{0}’...".format(defn.config['name']))
-            log_group = self._conn.create_log_group(defn.config['name'])
-            exist, arn = self.lookup_cloudwatch_log_group(log_group_name=defn.config['name'])
+            self.log(
+                "creating cloudwatch log group ‘{0}’...".format(defn.config["name"])
+            )
+            log_group = self._conn.create_log_group(defn.config["name"])
+            exist, arn = self.lookup_cloudwatch_log_group(
+                log_group_name=defn.config["name"]
+            )
 
-        if self.retention_in_days != defn.config['retentionInDays']:
-            self.log("setting the retention in days of '{0}' to '{1}'".format(defn.config['name'], defn.config['retentionInDays']))
-            self._conn.set_retention(log_group_name=defn.config['name'],retention_in_days=defn.config['retentionInDays'])
+        if self.retention_in_days != defn.config["retentionInDays"]:
+            self.log(
+                "setting the retention in days of '{0}' to '{1}'".format(
+                    defn.config["name"], defn.config["retentionInDays"]
+                )
+            )
+            self._conn.set_retention(
+                log_group_name=defn.config["name"],
+                retention_in_days=defn.config["retentionInDays"],
+            )
 
         with self.depl._db:
             self.state = self.UP
-            self.log_group_name = defn.config['name']
-            self.region = defn.config['region']
+            self.log_group_name = defn.config["name"]
+            self.region = defn.config["region"]
             self.arn = arn
-            self.retention_in_days = defn.config['retentionInDays']
+            self.retention_in_days = defn.config["retentionInDays"]
 
     def destroy(self, wipe=False):
         self._destroy()

--- a/nixopsaws/resources/cloudwatch_log_stream.py
+++ b/nixopsaws/resources/cloudwatch_log_stream.py
@@ -8,6 +8,7 @@ import nixops.util
 import nixops.resources
 import nixopsaws.ec2_utils
 
+
 class CloudWatchLogStreamDefinition(nixops.resources.ResourceDefinition):
     """Definition of a cloudwatch log stream."""
 
@@ -22,9 +23,13 @@ class CloudWatchLogStreamDefinition(nixops.resources.ResourceDefinition):
     def show_type(self):
         return "{0}".format(self.get_type())
 
+
 class CloudWatchLogStreamState(nixops.resources.ResourceState):
     """State of the cloudwatch log group"""
-    state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+
+    state = nixops.util.attr_property(
+        "state", nixops.resources.ResourceState.MISSING, int
+    )
     log_stream_name = nixops.util.attr_property("cloudwatch.logStreamName", None)
     log_group_name = nixops.util.attr_property("cloudwatch.logGroupName", None)
     region = nixops.util.attr_property("cloudwatch.region", None)
@@ -41,7 +46,8 @@ class CloudWatchLogStreamState(nixops.resources.ResourceState):
 
     def show_type(self):
         s = super(CloudWatchLogStreamState, self).show_type()
-        if self.region: s = "{0} [{1}]".format(s, self.region)
+        if self.region:
+            s = "{0} [{1}]".format(s, self.region)
         return s
 
     @property
@@ -49,29 +55,44 @@ class CloudWatchLogStreamState(nixops.resources.ResourceState):
         return self.log_stream_name
 
     def prefix_definition(self, attr):
-        return {('resources', 'cloudwatchLogStreams'): attr}
+        return {("resources", "cloudwatchLogStreams"): attr}
 
     def get_physical_spec(self):
-        return {'arn': self.arn}
+        return {"arn": self.arn}
 
     def get_definition_prefix(self):
         return "resources.cloudwatchLogStreams."
 
     def connect(self):
-        if self._conn: return
+        if self._conn:
+            return
         assert self.region
-        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(self.access_key_id)
+        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(
+            self.access_key_id
+        )
         self._conn = boto.logs.connect_to_region(
-            region_name=self.region, aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
+            region_name=self.region,
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+        )
 
     def _destroy(self):
-        if self.state != self.UP: return
+        if self.state != self.UP:
+            return
         self.connect()
-        self.log("destroying cloudwatch log stream ‘{0}’...".format(self.log_stream_name))
+        self.log(
+            "destroying cloudwatch log stream ‘{0}’...".format(self.log_stream_name)
+        )
         try:
-            self._conn.delete_log_stream(log_group_name=self.log_group_name,log_stream_name=self.log_stream_name)
-        except  boto.logs.exceptions.ResourceNotFoundException, e:
-            self.log("the log group ‘{0}’ or log stream ‘{1}’ was already deleted".format(self.log_group_name,self.log_stream_name))
+            self._conn.delete_log_stream(
+                log_group_name=self.log_group_name, log_stream_name=self.log_stream_name
+            )
+        except boto.logs.exceptions.ResourceNotFoundException, e:
+            self.log(
+                "the log group ‘{0}’ or log stream ‘{1}’ was already deleted".format(
+                    self.log_group_name, self.log_stream_name
+                )
+            )
         with self.depl._db:
             self.state = self.MISSING
             self.log_group_name = None
@@ -79,53 +100,82 @@ class CloudWatchLogStreamState(nixops.resources.ResourceState):
             self.region = None
             self.arn = None
 
-    def lookup_cloudwatch_log_stream(self, log_group_name, log_stream_name, next_token=None):
+    def lookup_cloudwatch_log_stream(
+        self, log_group_name, log_stream_name, next_token=None
+    ):
         if log_stream_name:
-         response = self._conn.describe_log_streams(log_group_name=log_group_name,
-           log_stream_name_prefix=log_stream_name,next_token=next_token)
-         if 'logStreams' in response:
-          for log_stream in response['logStreams']:
-              if log_stream_name == log_stream['logStreamName']:
-                  return True, log_stream['arn']
-         if 'nextToken' in response:
-             self.lookup_cloudwatch_log_group(log_group_name=log_group_name,
-              log_stream_name=log_stream_name,next_token=response['nextToken'])
+            response = self._conn.describe_log_streams(
+                log_group_name=log_group_name,
+                log_stream_name_prefix=log_stream_name,
+                next_token=next_token,
+            )
+            if "logStreams" in response:
+                for log_stream in response["logStreams"]:
+                    if log_stream_name == log_stream["logStreamName"]:
+                        return True, log_stream["arn"]
+            if "nextToken" in response:
+                self.lookup_cloudwatch_log_group(
+                    log_group_name=log_group_name,
+                    log_stream_name=log_stream_name,
+                    next_token=response["nextToken"],
+                )
         return False, None
 
     def create_after(self, resources, defn):
         # FIXME can be improved to check that we only need to wait for
         # the needed Log Groups to be created and not all Log Groups resources
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.cloudwatch_log_group.CloudWatchLogGroupState)}
+        return {
+            r
+            for r in resources
+            if isinstance(
+                r, nixopsaws.resources.cloudwatch_log_group.CloudWatchLogGroupState
+            )
+        }
 
     def create(self, defn, check, allow_reboot, allow_recreate):
-        self.access_key_id = defn.config['accessKeyId'] or nixopsaws.ec2_utils.get_access_key_id()
+        self.access_key_id = (
+            defn.config["accessKeyId"] or nixopsaws.ec2_utils.get_access_key_id()
+        )
         if not self.access_key_id:
-            raise Exception("please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID")
+            raise Exception(
+                "please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID"
+            )
 
-        if self.state == self.UP and (self.log_stream_name != defn.config['name'] or
-         self.log_group_name != defn.config['logGroupName'] or self.region != defn.config['region']):
+        if self.state == self.UP and (
+            self.log_stream_name != defn.config["name"]
+            or self.log_group_name != defn.config["logGroupName"]
+            or self.region != defn.config["region"]
+        ):
             self.log("cloudwatch log stream definition changed, recreating...")
             self._destroy()
             self._conn = None
 
-        self.region = defn.config['region']
+        self.region = defn.config["region"]
         self.connect()
-        exist, arn = self.lookup_cloudwatch_log_stream(log_group_name=self.log_group_name,
-         log_stream_name=self.log_stream_name)
+        exist, arn = self.lookup_cloudwatch_log_stream(
+            log_group_name=self.log_group_name, log_stream_name=self.log_stream_name
+        )
 
         if self.arn == None or not exist:
-            self.log("creating cloudwatch log stream ‘{0}’ under log group ‘{1}’...".format(defn.config['name'],defn.config['logGroupName']))
+            self.log(
+                "creating cloudwatch log stream ‘{0}’ under log group ‘{1}’...".format(
+                    defn.config["name"], defn.config["logGroupName"]
+                )
+            )
             log_group = self._conn.create_log_stream(
-             log_stream_name=defn.config['name'],log_group_name=defn.config['logGroupName'])
-            exist, arn = self.lookup_cloudwatch_log_stream(log_group_name=defn.config['logGroupName'],
-             log_stream_name=defn.config['name'])
+                log_stream_name=defn.config["name"],
+                log_group_name=defn.config["logGroupName"],
+            )
+            exist, arn = self.lookup_cloudwatch_log_stream(
+                log_group_name=defn.config["logGroupName"],
+                log_stream_name=defn.config["name"],
+            )
 
         with self.depl._db:
             self.state = self.UP
-            self.log_stream_name = defn.config['name']
-            self.log_group_name = defn.config['logGroupName']
-            self.region = defn.config['region']
+            self.log_stream_name = defn.config["name"]
+            self.log_group_name = defn.config["logGroupName"]
+            self.region = defn.config["region"]
             self.arn = arn
 
     def destroy(self, wipe=False):

--- a/nixopsaws/resources/ebs_volume.py
+++ b/nixopsaws/resources/ebs_volume.py
@@ -29,7 +29,9 @@ class EBSVolumeDefinition(nixops.resources.ResourceDefinition):
 class EBSVolumeState(nixops.resources.ResourceState, ec2_common.EC2CommonState):
     """State of an EBS volume."""
 
-    state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.ResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
     region = nixops.util.attr_property("ec2.region", None)
     zone = nixops.util.attr_property("ec2.zone", None)
@@ -38,143 +40,182 @@ class EBSVolumeState(nixops.resources.ResourceState, ec2_common.EC2CommonState):
     iops = nixops.util.attr_property("ec2.iops", None, int)
     volume_type = nixops.util.attr_property("ec2.volumeType", None)
 
-
     @classmethod
     def get_type(cls):
         return "ebs-volume"
-
 
     def __init__(self, depl, name, id):
         nixops.resources.ResourceState.__init__(self, depl, name, id)
         self._conn = None
         self._conn_boto3 = None
 
-
     def _exists(self):
         return self.state != self.MISSING
 
-
     def show_type(self):
         s = super(EBSVolumeState, self).show_type()
-        if self._exists(): s = "{0} [{1}; {2} GiB]".format(s, self.zone, self.size)
+        if self._exists():
+            s = "{0} [{1}; {2} GiB]".format(s, self.zone, self.size)
         return s
-
 
     @property
     def resource_id(self):
         return self.volume_id
 
-
     def connect(self, region):
-        if self._conn: return self._conn
+        if self._conn:
+            return self._conn
         self._conn = nixopsaws.ec2_utils.connect(region, self.access_key_id)
         return self._conn
 
     def connect_boto3(self, region):
-        if self._conn_boto3: return self._conn_boto3
-        self._conn_boto3 = nixopsaws.ec2_utils.connect_ec2_boto3(region, self.access_key_id)
+        if self._conn_boto3:
+            return self._conn_boto3
+        self._conn_boto3 = nixopsaws.ec2_utils.connect_ec2_boto3(
+            region, self.access_key_id
+        )
         return self._conn_boto3
 
     def _get_vol(self, config):
-        self.connect_boto3(config['region'])
+        self.connect_boto3(config["region"])
         try:
-            _vol = self._conn_boto3.describe_volumes(
-                    VolumeIds=[config['volumeId']]
-                   )['Volumes'][0]
+            _vol = self._conn_boto3.describe_volumes(VolumeIds=[config["volumeId"]])[
+                "Volumes"
+            ][0]
         except botocore.exceptions.ClientError as error:
             raise error
-        if _vol['VolumeType'] == "io1":
-            iops = _vol['Iops']
+        if _vol["VolumeType"] == "io1":
+            iops = _vol["Iops"]
         else:
-            iops = config['iops']
+            iops = config["iops"]
         with self.depl._db:
             self.state = self.STARTING
-            self.region = config['region']
-            self.zone = _vol['AvailabilityZone']
-            self.size = _vol['Size']
-            self.volume_id = config['volumeId']
+            self.region = config["region"]
+            self.zone = _vol["AvailabilityZone"]
+            self.size = _vol["Size"]
+            self.volume_id = config["volumeId"]
             self.iops = iops
-            self.volume_type = _vol['VolumeType']
+            self.volume_type = _vol["VolumeType"]
 
     def create(self, defn, check, allow_reboot, allow_recreate):
 
-        self.access_key_id = defn.config['accessKeyId'] or nixopsaws.ec2_utils.get_access_key_id()
+        self.access_key_id = (
+            defn.config["accessKeyId"] or nixopsaws.ec2_utils.get_access_key_id()
+        )
         if not self.access_key_id:
-            raise Exception("please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID")
+            raise Exception(
+                "please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID"
+            )
 
-        self.connect(defn.config['region'])
+        self.connect(defn.config["region"])
 
         if self._exists():
-            if self.region != defn.config['region'] or self.zone != defn.config['zone']:
-                raise Exception("changing the region or availability zone of an EBS volume is not supported")
+            if self.region != defn.config["region"] or self.zone != defn.config["zone"]:
+                raise Exception(
+                    "changing the region or availability zone of an EBS volume is not supported"
+                )
 
-            if defn.config['size'] != 0 and self.size != defn.config['size']:
-                raise Exception("changing the size an EBS volume is currently not supported")
+            if defn.config["size"] != 0 and self.size != defn.config["size"]:
+                raise Exception(
+                    "changing the size an EBS volume is currently not supported"
+                )
 
-            if self.volume_type != None and defn.config['volumeType'] != self.volume_type:
-                raise Exception("changing the type of an EBS volume is currently not supported")
+            if (
+                self.volume_type != None
+                and defn.config["volumeType"] != self.volume_type
+            ):
+                raise Exception(
+                    "changing the type of an EBS volume is currently not supported"
+                )
 
-            if defn.config['iops'] != self.iops:
-                raise Exception("changing the IOPS of an EBS volume is currently not supported")
+            if defn.config["iops"] != self.iops:
+                raise Exception(
+                    "changing the IOPS of an EBS volume is currently not supported"
+                )
 
         if self.state == self.MISSING:
-            if defn.config['volumeId']:
-                self.log("Using provided EBS volume ‘{0}’...".format(defn.config['volumeId']))
+            if defn.config["volumeId"]:
+                self.log(
+                    "Using provided EBS volume ‘{0}’...".format(defn.config["volumeId"])
+                )
                 self._get_vol(defn.config)
             else:
-                if defn.config['size'] == 0 and defn.config['snapshot'] != "":
-                    snapshots = self._conn.get_all_snapshots(snapshot_ids=[defn.config['snapshot']])
+                if defn.config["size"] == 0 and defn.config["snapshot"] != "":
+                    snapshots = self._conn.get_all_snapshots(
+                        snapshot_ids=[defn.config["snapshot"]]
+                    )
                     assert len(snapshots) == 1
-                    defn.config['size'] = snapshots[0].volume_size
+                    defn.config["size"] = snapshots[0].volume_size
 
-                if defn.config['snapshot']:
-                    self.log("creating EBS volume of {0} GiB from snapshot ‘{1}’...".format(defn.config['size'], defn.config['snapshot']))
+                if defn.config["snapshot"]:
+                    self.log(
+                        "creating EBS volume of {0} GiB from snapshot ‘{1}’...".format(
+                            defn.config["size"], defn.config["snapshot"]
+                        )
+                    )
                 else:
-                    self.log("creating EBS volume of {0} GiB...".format(defn.config['size']))
+                    self.log(
+                        "creating EBS volume of {0} GiB...".format(defn.config["size"])
+                    )
 
-                if defn.config['zone'] is None:
-                    raise Exception("please set a zone where the volume will be created")
+                if defn.config["zone"] is None:
+                    raise Exception(
+                        "please set a zone where the volume will be created"
+                    )
 
                 volume = self._conn.create_volume(
-                    zone=defn.config['zone'], size=defn.config['size'], snapshot=defn.config['snapshot'],
-                    iops=defn.config['iops'], volume_type=defn.config['volumeType'])
+                    zone=defn.config["zone"],
+                    size=defn.config["size"],
+                    snapshot=defn.config["snapshot"],
+                    iops=defn.config["iops"],
+                    volume_type=defn.config["volumeType"],
+                )
                 # FIXME: if we crash before the next step, we forget the
                 # volume we just created.  Doesn't seem to be anything we
                 # can do about this.
 
                 with self.depl._db:
                     self.state = self.STARTING
-                    self.region = defn.config['region']
-                    self.zone = defn.config['zone']
-                    self.size = defn.config['size']
+                    self.region = defn.config["region"]
+                    self.zone = defn.config["zone"]
+                    self.size = defn.config["size"]
                     self.volume_id = volume.id
-                    self.iops = defn.config['iops']
-                    self.volume_type = defn.config['volumeType']
+                    self.iops = defn.config["iops"]
+                    self.volume_type = defn.config["volumeType"]
 
                 self.log("volume ID is ‘{0}’".format(self.volume_id))
 
         if self.state == self.STARTING or check:
-            self.update_tags(self.volume_id, user_tags=defn.config['tags'], check=check)
+            self.update_tags(self.volume_id, user_tags=defn.config["tags"], check=check)
             nixopsaws.ec2_utils.wait_for_volume_available(
-                self._conn, self.volume_id, self.logger,
-                states=['available', 'in-use'])
+                self._conn, self.volume_id, self.logger, states=["available", "in-use"]
+            )
             self.state = self.UP
 
     def check(self):
-        volume = nixopsaws.ec2_utils.get_volume_by_id(self.connect(self.region), self.volume_id)
+        volume = nixopsaws.ec2_utils.get_volume_by_id(
+            self.connect(self.region), self.volume_id
+        )
         if volume is None:
             self.state = self.MISSING
 
     def destroy(self, wipe=False):
-        if not self._exists(): return True
+        if not self._exists():
+            return True
 
         if wipe:
             log.warn("wipe is not supported")
 
         self.connect(self.region)
-        volume = nixopsaws.ec2_utils.get_volume_by_id(self._conn, self.volume_id, allow_missing=True)
-        if not volume: return True
-        if not self.depl.logger.confirm("are you sure you want to destroy EBS volume ‘{0}’?".format(self.name)): return False
+        volume = nixopsaws.ec2_utils.get_volume_by_id(
+            self._conn, self.volume_id, allow_missing=True
+        )
+        if not volume:
+            return True
+        if not self.depl.logger.confirm(
+            "are you sure you want to destroy EBS volume ‘{0}’?".format(self.name)
+        ):
+            return False
         self.log("destroying EBS volume ‘{0}’...".format(self.volume_id))
         self._retry(lambda: volume.delete())
         return True

--- a/nixopsaws/resources/ec2_common.py
+++ b/nixopsaws/resources/ec2_common.py
@@ -8,28 +8,33 @@ import nixops.resources
 from nixops.diff import Diff, Handler
 import nixopsaws.ec2_utils
 
-class EC2CommonState():
 
-    COMMON_EC2_RESERVED = ['accessKeyId', 'ec2.tags']
+class EC2CommonState:
+
+    COMMON_EC2_RESERVED = ["accessKeyId", "ec2.tags"]
 
     def _retry(self, fun, **kwargs):
         return nixopsaws.ec2_utils.retry(fun, logger=self, **kwargs)
 
-    tags = nixops.util.attr_property("ec2.tags", {}, 'json')
+    tags = nixops.util.attr_property("ec2.tags", {}, "json")
 
     def get_common_tags(self):
-        tags = {'CharonNetworkUUID': self.depl.uuid,
-                'CharonMachineName': self.name,
-                'CharonStateFile': "{0}@{1}:{2}".format(getpass.getuser(), socket.gethostname(), self.depl._db.db_file)}
+        tags = {
+            "CharonNetworkUUID": self.depl.uuid,
+            "CharonMachineName": self.name,
+            "CharonStateFile": "{0}@{1}:{2}".format(
+                getpass.getuser(), socket.gethostname(), self.depl._db.db_file
+            ),
+        }
         if self.depl.name:
-            tags['CharonNetworkName'] = self.depl.name
+            tags["CharonNetworkName"] = self.depl.name
         return tags
 
     def get_default_name_tag(self):
         return "{0} [{1}]".format(self.depl.description, self.name)
 
     def update_tags_using(self, updater, user_tags={}, check=False):
-        tags = {'Name': self.get_default_name_tag()}
+        tags = {"Name": self.get_default_name_tag()}
         tags.update(user_tags)
         tags.update(self.get_common_tags())
 
@@ -38,7 +43,6 @@ class EC2CommonState():
             self.tags = tags
 
     def update_tags(self, id, user_tags={}, check=False):
-
         def updater(tags):
             # FIXME: handle removing tags.
             self._retry(lambda: self._conn.create_tags([id], tags))
@@ -46,26 +50,32 @@ class EC2CommonState():
         self.update_tags_using(updater, user_tags=user_tags, check=check)
 
     def get_client(self, service="ec2"):
-        '''
+        """
         Generic method to get a cached AWS client or create it.
-        '''
-        new_access_key_id = (self.get_defn()['accessKeyId'] if self.depl.definitions else None) \
-                            or nixopsaws.ec2_utils.get_access_key_id()
+        """
+        new_access_key_id = (
+            self.get_defn()["accessKeyId"] if self.depl.definitions else None
+        ) or nixopsaws.ec2_utils.get_access_key_id()
         if new_access_key_id is not None:
             self.access_key_id = new_access_key_id
         if self.access_key_id is None:
-            raise Exception("please set 'accessKeyId', $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID")
-        if hasattr(self, '_client'):
-            if self._client: return self._client
-        assert self._state['region']
-        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(self.access_key_id)
+            raise Exception(
+                "please set 'accessKeyId', $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID"
+            )
+        if hasattr(self, "_client"):
+            if self._client:
+                return self._client
+        assert self._state["region"]
+        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(
+            self.access_key_id
+        )
         self._client = boto3.session.Session().client(
             service_name=service,
-            region_name=self._state['region'],
+            region_name=self._state["region"],
             aws_access_key_id=access_key_id,
-            aws_secret_access_key=secret_access_key)
+            aws_secret_access_key=secret_access_key,
+        )
         return self._client
-
 
     def reset_client(self):
         self._client = None

--- a/nixopsaws/resources/ec2_keypair.py
+++ b/nixopsaws/resources/ec2_keypair.py
@@ -22,7 +22,9 @@ class EC2KeyPairDefinition(nixops.resources.ResourceDefinition):
         nixops.resources.ResourceDefinition.__init__(self, xml)
         self.keypair_name = xml.find("attrs/attr[@name='name']/string").get("value")
         self.region = xml.find("attrs/attr[@name='region']/string").get("value")
-        self.access_key_id = xml.find("attrs/attr[@name='accessKeyId']/string").get("value")
+        self.access_key_id = xml.find("attrs/attr[@name='accessKeyId']/string").get(
+            "value"
+        )
 
     def show_type(self):
         return "{0} [{1}]".format(self.get_type(), self.region)
@@ -31,53 +33,56 @@ class EC2KeyPairDefinition(nixops.resources.ResourceDefinition):
 class EC2KeyPairState(nixops.resources.ResourceState):
     """State of an EC2 key pair."""
 
-    state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.ResourceState.MISSING, int
+    )
     keypair_name = nixops.util.attr_property("ec2.keyPairName", None)
     public_key = nixops.util.attr_property("publicKey", None)
     private_key = nixops.util.attr_property("privateKey", None)
     access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
     region = nixops.util.attr_property("ec2.region", None)
 
-
     @classmethod
     def get_type(cls):
         return "ec2-keypair"
-
 
     def __init__(self, depl, name, id):
         nixops.resources.ResourceState.__init__(self, depl, name, id)
         self._conn = None
 
-
     def show_type(self):
         s = super(EC2KeyPairState, self).show_type()
-        if self.region: s = "{0} [{1}]".format(s, self.region)
+        if self.region:
+            s = "{0} [{1}]".format(s, self.region)
         return s
-
 
     @property
     def resource_id(self):
         return self.keypair_name
 
-
     def get_definition_prefix(self):
         return "resources.ec2KeyPairs."
 
-
     def connect(self):
-        if self._conn: return
+        if self._conn:
+            return
         self._conn = nixopsaws.ec2_utils.connect(self.region, self.access_key_id)
-
 
     def create(self, defn, check, allow_reboot, allow_recreate):
 
-        self.access_key_id = defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+        self.access_key_id = (
+            defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+        )
         if not self.access_key_id:
-            raise Exception("please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID")
+            raise Exception(
+                "please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID"
+            )
 
         # Generate the key pair locally.
         if not self.public_key:
-            (private, public) = nixops.util.create_key_pair(type="rsa") # EC2 only supports RSA keys.
+            (private, public) = nixops.util.create_key_pair(
+                type="rsa"
+            )  # EC2 only supports RSA keys.
             with self.depl._db:
                 self.public_key = public
                 self.private_key = private
@@ -98,7 +103,8 @@ class EC2KeyPairState(nixops.resources.ResourceState):
 
             # Don't re-upload the key if it exists and we're just checking.
             if not kp or self.state != self.UP:
-                if kp: self._conn.delete_key_pair(defn.keypair_name)
+                if kp:
+                    self._conn.delete_key_pair(defn.keypair_name)
                 self.log("uploading EC2 key pair ‘{0}’...".format(defn.keypair_name))
                 self._conn.import_key_pair(defn.keypair_name, self.public_key)
 
@@ -106,19 +112,27 @@ class EC2KeyPairState(nixops.resources.ResourceState):
                 self.state = self.UP
                 self.keypair_name = defn.keypair_name
 
-
     def destroy(self, wipe=False):
         def keypair_used():
             for m in self.depl.active_resources.itervalues():
-                if isinstance(m, nixopsaws.backends.ec2.EC2State) and m.key_pair == self.keypair_name:
+                if (
+                    isinstance(m, nixopsaws.backends.ec2.EC2State)
+                    and m.key_pair == self.keypair_name
+                ):
                     return m
             return None
 
         m = keypair_used()
         if m:
-            raise Exception("keypair ‘{0}’ is still in use by ‘{1}’ ({2})".format(self.keypair_name, m.name, m.vm_id))
+            raise Exception(
+                "keypair ‘{0}’ is still in use by ‘{1}’ ({2})".format(
+                    self.keypair_name, m.name, m.vm_id
+                )
+            )
 
-        if not self.depl.logger.confirm("are you sure you want to destroy keypair ‘{0}’?".format(self.keypair_name)):
+        if not self.depl.logger.confirm(
+            "are you sure you want to destroy keypair ‘{0}’?".format(self.keypair_name)
+        ):
             return False
 
         if self.state == self.UP:

--- a/nixopsaws/resources/ec2_placement_group.py
+++ b/nixopsaws/resources/ec2_placement_group.py
@@ -7,6 +7,7 @@ import nixops.resources
 import nixops.util
 import nixopsaws.ec2_utils
 
+
 class EC2PlacementGroupDefinition(nixops.resources.ResourceDefinition):
     """Definition of an EC2 placement group."""
 
@@ -20,21 +21,32 @@ class EC2PlacementGroupDefinition(nixops.resources.ResourceDefinition):
 
     def __init__(self, xml):
         super(EC2PlacementGroupDefinition, self).__init__(xml)
-        self.placement_group_name = xml.find("attrs/attr[@name='name']/string").get("value")
-        self.placement_group_strategy = xml.find("attrs/attr[@name='strategy']/string").get("value")
+        self.placement_group_name = xml.find("attrs/attr[@name='name']/string").get(
+            "value"
+        )
+        self.placement_group_strategy = xml.find(
+            "attrs/attr[@name='strategy']/string"
+        ).get("value")
         self.region = xml.find("attrs/attr[@name='region']/string").get("value")
-        self.access_key_id = xml.find("attrs/attr[@name='accessKeyId']/string").get("value")
+        self.access_key_id = xml.find("attrs/attr[@name='accessKeyId']/string").get(
+            "value"
+        )
 
     def show_type(self):
         return "{0} [{1}]".format(self.get_type(), self.region)
+
 
 class EC2PlacementGroupState(nixops.resources.ResourceState):
     """State of an EC2 placement group."""
 
     region = nixops.util.attr_property("ec2.region", None)
     placement_group_name = nixops.util.attr_property("ec2.placementGroupName", None)
-    placement_group_strategy = nixops.util.attr_property("ec2.placementGroupStrategy", None)
-    old_placement_groups = nixops.util.attr_property("ec2.oldPlacementGroups", [], 'json')
+    placement_group_strategy = nixops.util.attr_property(
+        "ec2.placementGroupStrategy", None
+    )
+    old_placement_groups = nixops.util.attr_property(
+        "ec2.oldPlacementGroups", [], "json"
+    )
     access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
 
     @classmethod
@@ -47,11 +59,12 @@ class EC2PlacementGroupState(nixops.resources.ResourceState):
 
     def show_type(self):
         s = super(EC2PlacementGroupState, self).show_type()
-        if self.region: s = "{0} [{1}]".format(s, self.region)
+        if self.region:
+            s = "{0} [{1}]".format(s, self.region)
         return s
 
     def prefix_definition(self, attr):
-        return {('resources', 'ec2PlacementGroups'): attr}
+        return {("resources", "ec2PlacementGroups"): attr}
 
     def get_physical_spec(self):
         return {}
@@ -61,19 +74,27 @@ class EC2PlacementGroupState(nixops.resources.ResourceState):
         return self.placement_group_name
 
     def _connect(self):
-        if self._conn: return
+        if self._conn:
+            return
         self._conn = nixopsaws.ec2_utils.connect(self.region, self.access_key_id)
 
     def create(self, defn, check, allow_reboot, allow_recreate):
         # Name or region change means a completely new security group
-        if self.placement_group_name and (defn.placement_group_name != self.placement_group_name or defn.region != self.region):
+        if self.placement_group_name and (
+            defn.placement_group_name != self.placement_group_name
+            or defn.region != self.region
+        ):
             with self.depl._db:
                 self.state = self.UNKNOWN
-                self.old_placement_groups = self.old_placement_groups + [{'name': self.placement_group_name, 'region': self.region}]
+                self.old_placement_groups = self.old_placement_groups + [
+                    {"name": self.placement_group_name, "region": self.region}
+                ]
 
         with self.depl._db:
             self.region = defn.region
-            self.access_key_id = defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+            self.access_key_id = (
+                defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+            )
             self.placement_group_name = defn.placement_group_name
             self.placement_group_strategy = defn.placement_group_strategy
 
@@ -83,11 +104,13 @@ class EC2PlacementGroupState(nixops.resources.ResourceState):
                 self._connect()
 
                 try:
-                    grp = self._conn.get_all_placement_groups([ defn.placement_group_name ])[0]
+                    grp = self._conn.get_all_placement_groups(
+                        [defn.placement_group_name]
+                    )[0]
                     self.state = self.UP
                     self.placement_group_strategy = grp.strategy
                 except boto.exception.EC2ResponseError as e:
-                    if e.error_code == u'InvalidGroup.NotFound':
+                    if e.error_code == u"InvalidGroup.NotFound":
                         self.state = self.Missing
                     else:
                         raise
@@ -95,10 +118,19 @@ class EC2PlacementGroupState(nixops.resources.ResourceState):
         if self.state == self.MISSING or self.state == self.UNKNOWN:
             self._connect()
             try:
-                self.logger.log("creating EC2 placement group ‘{0}’...".format(self.placement_group_name))
-                created = self._conn.create_placement_group(self.placement_group_name, self.placement_group_strategy)
+                self.logger.log(
+                    "creating EC2 placement group ‘{0}’...".format(
+                        self.placement_group_name
+                    )
+                )
+                created = self._conn.create_placement_group(
+                    self.placement_group_name, self.placement_group_strategy
+                )
             except boto.exception.EC2ResponseError as e:
-                if self.state != self.UNKNOWN or e.error_code != u'InvalidGroup.Duplicate':
+                if (
+                    self.state != self.UNKNOWN
+                    or e.error_code != u"InvalidGroup.Duplicate"
+                ):
                     raise
 
         self.state = self.UP
@@ -108,19 +140,23 @@ class EC2PlacementGroupState(nixops.resources.ResourceState):
         self._connect()
         conn = self._conn
         for group in self.old_placement_groups:
-            if group['region'] != region:
-                region = group['region']
+            if group["region"] != region:
+                region = group["region"]
                 conn = nixopsaws.ec2_utils.connect(region, self.access_key_id)
             try:
-                conn.delete_placement_group(group['name'])
+                conn.delete_placement_group(group["name"])
             except boto.exception.EC2ResponseError as e:
-                if e.error_code != u'InvalidGroup.NotFound':
+                if e.error_code != u"InvalidGroup.NotFound":
                     raise
         self.old_placement_groups = []
 
     def destroy(self, wipe=False):
         if self.state == self.UP or self.state == self.STARTING:
-            self.logger.log("deleting EC2 placement group `{0}'...".format(self.placement_group_name))
+            self.logger.log(
+                "deleting EC2 placement group `{0}'...".format(
+                    self.placement_group_name
+                )
+            )
             self._connect()
             self._conn.delete_placement_group(self.placement_group_name)
             self.state = self.MISSING

--- a/nixopsaws/resources/ec2_rds_dbinstance.py
+++ b/nixopsaws/resources/ec2_rds_dbinstance.py
@@ -9,6 +9,7 @@ import nixopsaws.ec2_utils
 import time
 from uuid import uuid4
 
+
 class EC2RDSDbInstanceDefinition(nixops.resources.ResourceDefinition):
     """Definition of an EC2 RDS Database Instance."""
 
@@ -24,27 +25,46 @@ class EC2RDSDbInstanceDefinition(nixops.resources.ResourceDefinition):
         super(EC2RDSDbInstanceDefinition, self).__init__(xml)
         # rds specific params
         self.rds_dbinstance_id = xml.find("attrs/attr[@name='id']/string").get("value")
-        self.rds_dbinstance_allocated_storage = int(xml.find("attrs/attr[@name='allocatedStorage']/int").get("value"))
-        self.rds_dbinstance_instance_class = xml.find("attrs/attr[@name='instanceClass']/string").get("value")
-        self.rds_dbinstance_master_username = xml.find("attrs/attr[@name='masterUsername']/string").get("value")
-        self.rds_dbinstance_master_password = xml.find("attrs/attr[@name='masterPassword']/string").get("value")
-        self.rds_dbinstance_port = int(xml.find("attrs/attr[@name='port']/int").get("value"))
-        self.rds_dbinstance_engine = xml.find("attrs/attr[@name='engine']/string").get("value")
-        self.rds_dbinstance_db_name = xml.find("attrs/attr[@name='dbName']/string").get("value")
-        self.rds_dbinstance_multi_az = xml.find("attrs/attr[@name='multiAZ']/bool").get("value") == "true"
+        self.rds_dbinstance_allocated_storage = int(
+            xml.find("attrs/attr[@name='allocatedStorage']/int").get("value")
+        )
+        self.rds_dbinstance_instance_class = xml.find(
+            "attrs/attr[@name='instanceClass']/string"
+        ).get("value")
+        self.rds_dbinstance_master_username = xml.find(
+            "attrs/attr[@name='masterUsername']/string"
+        ).get("value")
+        self.rds_dbinstance_master_password = xml.find(
+            "attrs/attr[@name='masterPassword']/string"
+        ).get("value")
+        self.rds_dbinstance_port = int(
+            xml.find("attrs/attr[@name='port']/int").get("value")
+        )
+        self.rds_dbinstance_engine = xml.find("attrs/attr[@name='engine']/string").get(
+            "value"
+        )
+        self.rds_dbinstance_db_name = xml.find("attrs/attr[@name='dbName']/string").get(
+            "value"
+        )
+        self.rds_dbinstance_multi_az = (
+            xml.find("attrs/attr[@name='multiAZ']/bool").get("value") == "true"
+        )
         self.rds_dbinstance_security_groups = []
         for sg in xml.findall("attrs/attr[@name='securityGroups']/list"):
             for sg_str in sg.findall("string"):
-               sg_name =  sg_str.get("value")
-               self.rds_dbinstance_security_groups.append(sg_name)
+                sg_name = sg_str.get("value")
+                self.rds_dbinstance_security_groups.append(sg_name)
         # TODO: implement remainder of boto.rds.RDSConnection.create_dbinstance parameters
 
         # common params
         self.region = xml.find("attrs/attr[@name='region']/string").get("value")
-        self.access_key_id = xml.find("attrs/attr[@name='accessKeyId']/string").get("value")
+        self.access_key_id = xml.find("attrs/attr[@name='accessKeyId']/string").get(
+            "value"
+        )
 
     def show_type(self):
         return "{0} [{1}]".format(self.get_type(), self.region)
+
 
 class EC2RDSDbInstanceState(nixops.resources.ResourceState):
     """State of an RDS Database Instance."""
@@ -52,19 +72,33 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState):
     region = nixops.util.attr_property("ec2.region", None)
     access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
     rds_dbinstance_id = nixops.util.attr_property("ec2.rdsDbInstanceID", None)
-    rds_dbinstance_allocated_storage = nixops.util.attr_property("ec2.rdsAllocatedStorage", None, int)
-    rds_dbinstance_instance_class = nixops.util.attr_property("ec2.rdsInstanceClass", None)
-    rds_dbinstance_master_username = nixops.util.attr_property("ec2.rdsMasterUsername", None)
-    rds_dbinstance_master_password = nixops.util.attr_property("ec2.rdsMasterPassword", None)
+    rds_dbinstance_allocated_storage = nixops.util.attr_property(
+        "ec2.rdsAllocatedStorage", None, int
+    )
+    rds_dbinstance_instance_class = nixops.util.attr_property(
+        "ec2.rdsInstanceClass", None
+    )
+    rds_dbinstance_master_username = nixops.util.attr_property(
+        "ec2.rdsMasterUsername", None
+    )
+    rds_dbinstance_master_password = nixops.util.attr_property(
+        "ec2.rdsMasterPassword", None
+    )
     rds_dbinstance_port = nixops.util.attr_property("ec2.rdsPort", None, int)
     rds_dbinstance_engine = nixops.util.attr_property("ec2.rdsEngine", None)
     rds_dbinstance_db_name = nixops.util.attr_property("ec2.rdsDbName", None)
     rds_dbinstance_endpoint = nixops.util.attr_property("ec2.rdsEndpoint", None)
     rds_dbinstance_multi_az = nixops.util.attr_property("ec2.multiAZ", False)
-    rds_dbinstance_security_groups = nixops.util.attr_property("ec2.securityGroups", [], "json")
+    rds_dbinstance_security_groups = nixops.util.attr_property(
+        "ec2.securityGroups", [], "json"
+    )
 
-    requires_reboot_attrs = ('rds_dbinstance_id', 'rds_dbinstance_allocated_storage',
-        'rds_dbinstance_instance_class', 'rds_dbinstance_master_password')
+    requires_reboot_attrs = (
+        "rds_dbinstance_id",
+        "rds_dbinstance_allocated_storage",
+        "rds_dbinstance_instance_class",
+        "rds_dbinstance_master_password",
+    )
 
     @classmethod
     def get_type(cls):
@@ -76,28 +110,41 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState):
 
     def show_type(self):
         s = super(EC2RDSDbInstanceState, self).show_type()
-        if self.region: s = "{0} [{1}]".format(s, self.region)
+        if self.region:
+            s = "{0} [{1}]".format(s, self.region)
         return s
 
     def prefix_definition(self, attr):
-        return {('resources', 'rdsDbInstances'): attr}
+        return {("resources", "rdsDbInstances"): attr}
 
     def get_physical_spec(self):
-        return {'endpoint': self.rds_dbinstance_endpoint}
+        return {"endpoint": self.rds_dbinstance_endpoint}
 
     @property
     def resource_id(self):
         return self.rds_dbinstance_id
 
     def create_after(self, resources, defn):
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.ec2_rds_dbsecurity_group.EC2RDSDbSecurityGroupState)}
+        return {
+            r
+            for r in resources
+            if isinstance(
+                r,
+                nixopsaws.resources.ec2_rds_dbsecurity_group.EC2RDSDbSecurityGroupState,
+            )
+        }
 
     def _connect(self):
-        if self._conn: return
-        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(self.access_key_id)
+        if self._conn:
+            return
+        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(
+            self.access_key_id
+        )
         self._conn = boto.rds.connect_to_region(
-            region_name=self.region, aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
+            region_name=self.region,
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+        )
 
     def _exists(self):
         return self.state != self.MISSING and self.state != self.UNKNOWN
@@ -112,12 +159,22 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState):
         diff = self._diff_defn(defn)
         diff_attrs = set(diff.keys())
 
-        invariant_attrs = set(['region', 'rds_dbinstance_master_username',
-            'rds_dbinstance_engine', 'rds_dbinstance_port', 'rds_dbinstance_db_name'])
+        invariant_attrs = set(
+            [
+                "region",
+                "rds_dbinstance_master_username",
+                "rds_dbinstance_engine",
+                "rds_dbinstance_port",
+                "rds_dbinstance_db_name",
+            ]
+        )
 
         violated_attrs = diff_attrs & invariant_attrs
         if len(violated_attrs) > 0:
-            message = "Invariant violated: (%s) cannot be changed for an RDS instance" % ','.join(violated_attrs)
+            message = (
+                "Invariant violated: (%s) cannot be changed for an RDS instance"
+                % ",".join(violated_attrs)
+            )
             for attr in violated_attrs:
                 message += "\n%s != %s" % (getattr(self, attr), getattr(defn, attr))
             raise Exception(message)
@@ -127,7 +184,7 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState):
         try:
             dbinstance = self._conn.get_all_dbinstances(instance_id=instance_id)[0]
         except boto.exception.BotoServerError as bse:
-            if bse.error_code == u'DBInstanceNotFound':
+            if bse.error_code == u"DBInstanceNotFound":
                 dbinstance = None
             else:
                 raise
@@ -135,37 +192,61 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState):
         return dbinstance
 
     def _diff_defn(self, defn):
-        attrs = ('region', 'rds_dbinstance_port', 'rds_dbinstance_engine', 'rds_dbinstance_multi_az',
-            'rds_dbinstance_instance_class', 'rds_dbinstance_db_name', 'rds_dbinstance_master_username',
-            'rds_dbinstance_master_password', 'rds_dbinstance_allocated_storage', 'rds_dbinstance_security_groups')
+        attrs = (
+            "region",
+            "rds_dbinstance_port",
+            "rds_dbinstance_engine",
+            "rds_dbinstance_multi_az",
+            "rds_dbinstance_instance_class",
+            "rds_dbinstance_db_name",
+            "rds_dbinstance_master_username",
+            "rds_dbinstance_master_password",
+            "rds_dbinstance_allocated_storage",
+            "rds_dbinstance_security_groups",
+        )
 
         def get_state_attr(attr):
             # handle boolean type in the state to avoid triggering false
             # diffs
-            if attr == 'rds_dbinstance_multi_az':
+            if attr == "rds_dbinstance_multi_az":
                 return bool(getattr(self, attr))
             else:
                 return getattr(self, attr)
 
         def get_defn_attr(attr):
-            if attr == 'rds_dbinstance_security_groups':
-                return self.fetch_security_group_resources(defn.rds_dbinstance_security_groups)
+            if attr == "rds_dbinstance_security_groups":
+                return self.fetch_security_group_resources(
+                    defn.rds_dbinstance_security_groups
+                )
             else:
                 return getattr(defn, attr)
 
-        return { attr : get_defn_attr(attr) for attr in attrs if get_defn_attr(attr) != get_state_attr(attr) }
+        return {
+            attr: get_defn_attr(attr)
+            for attr in attrs
+            if get_defn_attr(attr) != get_state_attr(attr)
+        }
 
     def _requires_reboot(self, defn):
         diff = self._diff_defn(defn)
         return set(self.requires_reboot_attrs) & set(diff.keys())
 
-    def _wait_for_dbinstance(self, dbinstance, state='available'):
+    def _wait_for_dbinstance(self, dbinstance, state="available"):
         self.log_start("waiting for database instance state=`{0}` ".format(state))
         while True:
             dbinstance.update()
             self.log_continue("[{0}] ".format(dbinstance.status))
-            if dbinstance.status not in {'creating', 'backing-up', 'available', 'modifying'}:
-                raise Exception("RDS database instance ‘{0}’ in an error state (state is ‘{1}’)".format(dbinstance.id, dbinstance.status))
+            if dbinstance.status not in {
+                "creating",
+                "backing-up",
+                "available",
+                "modifying",
+            }:
+                raise Exception(
+                    "RDS database instance ‘{0}’ in an error state (state is ‘{1}’)".format(
+                        dbinstance.id, dbinstance.status
+                    )
+                )
             if dbinstance.status == state:
                 break
             time.sleep(6)
@@ -179,18 +260,18 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState):
             self.rds_dbinstance_engine = dbinstance.engine
             self.rds_dbinstance_multi_az = dbinstance.multi_az
             self.rds_dbinstance_port = int(dbinstance.endpoint[1])
-            self.rds_dbinstance_endpoint = "%s:%d"% dbinstance.endpoint
+            self.rds_dbinstance_endpoint = "%s:%d" % dbinstance.endpoint
             self.rds_dbinstance_security_groups = security_groups
 
     def _to_boto_kwargs(self, attrs):
         attr_to_kwarg = {
-            'rds_dbinstance_allocated_storage': 'allocated_storage',
-            'rds_dbinstance_master_password': 'master_password',
-            'rds_dbinstance_instance_class': 'instance_class',
-            'rds_dbinstance_multi_az': 'multi_az',
-            'rds_dbinstance_security_groups': 'security_groups'
+            "rds_dbinstance_allocated_storage": "allocated_storage",
+            "rds_dbinstance_master_password": "master_password",
+            "rds_dbinstance_instance_class": "instance_class",
+            "rds_dbinstance_multi_az": "multi_az",
+            "rds_dbinstance_security_groups": "security_groups",
         }
-        return { attr_to_kwarg[attr] : attrs[attr] for attr in attrs.keys() }
+        return {attr_to_kwarg[attr]: attrs[attr] for attr in attrs.keys()}
 
     def _compare_instance_id(self, instance_id):
         # take care when comparing instance ids, as aws lowercases and converts to unicode
@@ -200,17 +281,23 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState):
         security_groups = []
         for sg in config:
             if sg.startswith("res-"):
-                res = self.depl.get_typed_resource(sg[4:].split(".")[0], "ec2-rds-dbsecurity-group")
-                security_groups.append(res._state['groupName'])
+                res = self.depl.get_typed_resource(
+                    sg[4:].split(".")[0], "ec2-rds-dbsecurity-group"
+                )
+                security_groups.append(res._state["groupName"])
             else:
                 security_groups.append(sg)
         return security_groups
 
     def create(self, defn, check, allow_reboot, allow_recreate):
         with self.depl._db:
-            self.access_key_id = defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+            self.access_key_id = (
+                defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+            )
             if not self.access_key_id:
-                raise Exception("please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID")
+                raise Exception(
+                    "please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID"
+                )
 
             if self._exists():
                 self._assert_invariants(defn)
@@ -225,70 +312,112 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState):
             # if we are changing instance ids and our target instance id already exists
             # there is no reasonable recourse.  bail.
             if dbinstance and not self._compare_instance_id(defn.rds_dbinstance_id):
-                raise Exception("database identifier changed but database with instance_id=%s already exists" % defn.rds_dbinstance_id)
+                raise Exception(
+                    "database identifier changed but database with instance_id=%s already exists"
+                    % defn.rds_dbinstance_id
+                )
 
             dbinstance = self._try_fetch_dbinstance(self.rds_dbinstance_id)
 
         with self.depl._db:
             if check or self.state == self.MISSING or self.state == self.UNKNOWN:
-                if dbinstance and (self.state == self.MISSING or self.state == self.UNKNOWN):
-                    if dbinstance.status == 'deleting':
-                        self.logger.log("RDS instance `{0}` is being deleted, waiting...".format(dbinstance.id))
+                if dbinstance and (
+                    self.state == self.MISSING or self.state == self.UNKNOWN
+                ):
+                    if dbinstance.status == "deleting":
+                        self.logger.log(
+                            "RDS instance `{0}` is being deleted, waiting...".format(
+                                dbinstance.id
+                            )
+                        )
                         while True:
-                            if dbinstance.status == 'deleting':
+                            if dbinstance.status == "deleting":
                                 continue
                             else:
                                 break
                             self.log_continue("[{0}] ".format(dbinstance.status))
                             time.sleep(6)
 
-                    self.logger.log("RDS instance `{0}` is MISSING but already exists, synchronizing state".format(dbinstance.id))
+                    self.logger.log(
+                        "RDS instance `{0}` is MISSING but already exists, synchronizing state".format(
+                            dbinstance.id
+                        )
+                    )
                     self.state = self.UP
 
                 if not dbinstance and self.state == self.UP:
-                    self.logger.log("RDS instance `{0}` state is UP but does not exist!")
+                    self.logger.log(
+                        "RDS instance `{0}` state is UP but does not exist!"
+                    )
                     if not allow_recreate:
-                        raise Exception("RDS instance is UP but does not exist, set --allow-recreate to recreate")
+                        raise Exception(
+                            "RDS instance is UP but does not exist, set --allow-recreate to recreate"
+                        )
                     self.state = MISSING
 
-                if not dbinstance and (self.state == self.MISSING or self.state == self.UNKNOWN):
-                    self.logger.log("creating RDS database instance ‘{0}’ (this may take a while)...".format(defn.rds_dbinstance_id))
+                if not dbinstance and (
+                    self.state == self.MISSING or self.state == self.UNKNOWN
+                ):
+                    self.logger.log(
+                        "creating RDS database instance ‘{0}’ (this may take a while)...".format(
+                            defn.rds_dbinstance_id
+                        )
+                    )
                     # create a new dbinstance with desired config
-                    security_groups = self.fetch_security_group_resources(defn.rds_dbinstance_security_groups)
-                    dbinstance = self._conn.create_dbinstance(defn.rds_dbinstance_id,
-                        defn.rds_dbinstance_allocated_storage, defn.rds_dbinstance_instance_class,
-                        defn.rds_dbinstance_master_username, defn.rds_dbinstance_master_password,
-                        port=defn.rds_dbinstance_port, engine=defn.rds_dbinstance_engine,
-                        db_name=defn.rds_dbinstance_db_name, multi_az=defn.rds_dbinstance_multi_az,
-                        security_groups=security_groups)
+                    security_groups = self.fetch_security_group_resources(
+                        defn.rds_dbinstance_security_groups
+                    )
+                    dbinstance = self._conn.create_dbinstance(
+                        defn.rds_dbinstance_id,
+                        defn.rds_dbinstance_allocated_storage,
+                        defn.rds_dbinstance_instance_class,
+                        defn.rds_dbinstance_master_username,
+                        defn.rds_dbinstance_master_password,
+                        port=defn.rds_dbinstance_port,
+                        engine=defn.rds_dbinstance_engine,
+                        db_name=defn.rds_dbinstance_db_name,
+                        multi_az=defn.rds_dbinstance_multi_az,
+                        security_groups=security_groups,
+                    )
 
                     self.state = self.STARTING
                     self._wait_for_dbinstance(dbinstance)
 
                 self.region = defn.region
-                self.access_key_id = defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+                self.access_key_id = (
+                    defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+                )
                 self.rds_dbinstance_db_name = defn.rds_dbinstance_db_name
-                self.rds_dbinstance_master_password = defn.rds_dbinstance_master_password
-                self._copy_dbinstance_attrs(dbinstance, defn.rds_dbinstance_security_groups)
+                self.rds_dbinstance_master_password = (
+                    defn.rds_dbinstance_master_password
+                )
+                self._copy_dbinstance_attrs(
+                    dbinstance, defn.rds_dbinstance_security_groups
+                )
                 self.state = self.UP
 
         with self.depl._db:
             if self.state == self.UP and self._diff_defn(defn):
                 if dbinstance is None:
-                    raise Exception("state is UP but database instance does not exist. re-run with --check option to synchronize states")
+                    raise Exception(
+                        "state is UP but database instance does not exist. re-run with --check option to synchronize states"
+                    )
 
                 # check invariants again since state possibly changed due to check = true
                 self._assert_invariants(defn)
 
                 reboot_keys = self._requires_reboot(defn)
                 if self._requires_reboot(defn) and not allow_reboot:
-                    raise Exception("changing keys (%s) requires reboot, but --allow-reboot not set" % ', '.join(reboot_keys))
+                    raise Exception(
+                        "changing keys (%s) requires reboot, but --allow-reboot not set"
+                        % ", ".join(reboot_keys)
+                    )
 
                 diff = self._diff_defn(defn)
                 boto_kwargs = self._to_boto_kwargs(diff)
                 if not self._compare_instance_id(defn.rds_dbinstance_id):
-                    boto_kwargs['new_instance_id'] = defn.rds_dbinstance_id
-                boto_kwargs['apply_immediately'] = True
+                    boto_kwargs["new_instance_id"] = defn.rds_dbinstance_id
+                boto_kwargs["apply_immediately"] = True
 
                 # first check is for the unlikely event we attempt to modify the db during its maintenance window
                 self._wait_for_dbinstance(dbinstance)
@@ -296,11 +425,12 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState):
                 # Ugly hack to prevent from waiting on state
                 # 'modifying' on sg change as that looks like it's an
                 # immediate change in RDS.
-                if not (len(boto_kwargs) == 2 and 'security_groups' in boto_kwargs):
+                if not (len(boto_kwargs) == 2 and "security_groups" in boto_kwargs):
                     self._wait_for_dbinstance(dbinstance, state="modifying")
                 self._wait_for_dbinstance(dbinstance)
-                self._copy_dbinstance_attrs(dbinstance, defn.rds_dbinstance_security_groups)
-
+                self._copy_dbinstance_attrs(
+                    dbinstance, defn.rds_dbinstance_security_groups
+                )
 
     def after_activation(self, defn):
         # TODO: Warn about old instances, but don't clean them up.
@@ -308,7 +438,11 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState):
 
     def destroy(self, wipe=False):
         if self.state == self.UP or self.state == self.STARTING:
-            if not self.depl.logger.confirm("are you sure you want to destroy RDS instance ‘{0}’?".format(self.rds_dbinstance_id)):
+            if not self.depl.logger.confirm(
+                "are you sure you want to destroy RDS instance ‘{0}’?".format(
+                    self.rds_dbinstance_id
+                )
+            ):
                 return False
             self._connect()
 
@@ -316,14 +450,21 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState):
             if self.rds_dbinstance_id:
                 dbinstance = self._try_fetch_dbinstance(self.rds_dbinstance_id)
 
-            if dbinstance and dbinstance.status != 'deleting':
-                self.logger.log("deleting RDS instance `{0}'...".format(self.rds_dbinstance_id))
-                final_snapshot_id = "%s-final-snapshot-%s" % (self.rds_dbinstance_id, uuid4().hex)
+            if dbinstance and dbinstance.status != "deleting":
+                self.logger.log(
+                    "deleting RDS instance `{0}'...".format(self.rds_dbinstance_id)
+                )
+                final_snapshot_id = "%s-final-snapshot-%s" % (
+                    self.rds_dbinstance_id,
+                    uuid4().hex,
+                )
                 self.logger.log("saving final snapshot as %s" % final_snapshot_id)
-                self._conn.delete_dbinstance(self.rds_dbinstance_id, final_snapshot_id=final_snapshot_id)
+                self._conn.delete_dbinstance(
+                    self.rds_dbinstance_id, final_snapshot_id=final_snapshot_id
+                )
 
                 while True:
-                    if dbinstance.status == 'deleting':
+                    if dbinstance.status == "deleting":
                         continue
                     else:
                         break
@@ -331,7 +472,11 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState):
                     time.sleep(6)
 
             else:
-                self.logger.log("RDS instance `{0}` does not exist, skipping.".format(self.rds_dbinstance_id))
+                self.logger.log(
+                    "RDS instance `{0}` does not exist, skipping.".format(
+                        self.rds_dbinstance_id
+                    )
+                )
 
             self.state = self.MISSING
         return True

--- a/nixopsaws/resources/ec2_rds_dbsecurity_group.py
+++ b/nixopsaws/resources/ec2_rds_dbsecurity_group.py
@@ -8,8 +8,8 @@ import nixopsaws.ec2_utils
 from nixopsaws.resources.ec2_common import EC2CommonState
 from nixops.diff import Diff, Handler
 
-class EC2RDSDbSecurityGroupDefinition(nixops.resources.ResourceDefinition):
 
+class EC2RDSDbSecurityGroupDefinition(nixops.resources.ResourceDefinition):
     @classmethod
     def get_type(cls):
         return "ec2-rds-dbsecurity-group"
@@ -21,9 +21,14 @@ class EC2RDSDbSecurityGroupDefinition(nixops.resources.ResourceDefinition):
     def show_type(self):
         return "{0}".format(self.get_type())
 
-class EC2RDSDbSecurityGroupState(nixops.resources.DiffEngineResourceState, EC2CommonState):
 
-    state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+class EC2RDSDbSecurityGroupState(
+    nixops.resources.DiffEngineResourceState, EC2CommonState
+):
+
+    state = nixops.util.attr_property(
+        "state", nixops.resources.ResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("accessKeyId", None)
     _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED
 
@@ -34,37 +39,44 @@ class EC2RDSDbSecurityGroupState(nixops.resources.DiffEngineResourceState, EC2Co
     def __init__(self, depl, name, id):
         nixops.resources.DiffEngineResourceState.__init__(self, depl, name, id)
         self.handle_create_rds_db_sg = Handler(
-            ['groupName', 'region', 'description'],
-            handle=self.realize_create_sg)
+            ["groupName", "region", "description"], handle=self.realize_create_sg
+        )
         self.handle_rules = Handler(
-            ['rules'],
+            ["rules"],
             after=[self.handle_create_rds_db_sg],
-            handle=self.realize_rules_change)
+            handle=self.realize_rules_change,
+        )
 
     def show_type(self):
         s = super(EC2RDSDbSecurityGroupState, self).show_type()
-        return "{0} [{1}]".format(s, self._state.get('region', None))
+        return "{0} [{1}]".format(s, self._state.get("region", None))
 
     @property
     def resource_id(self):
-        return self._state.get('groupName', None)
+        return self._state.get("groupName", None)
 
     def _check(self):
-        if self._state.get('groupName', None) is None:
+        if self._state.get("groupName", None) is None:
             return
         if self.state == self.UP:
             try:
                 response = self.get_client("rds").describe_db_security_groups(
-                    DBSecurityGroupName=self._state['groupName'])
+                    DBSecurityGroupName=self._state["groupName"]
+                )
             except botocore.exceptions.ClientError as error:
-                if error.response['Error']['Code'] == 'DBSecurityGroupNotFound':
-                    self.warn("RDS db security group {} not found, performing destroy to sync the state ...".format(self._state['groupName']))
+                if error.response["Error"]["Code"] == "DBSecurityGroupNotFound":
+                    self.warn(
+                        "RDS db security group {} not found, performing destroy to sync the state ...".format(
+                            self._state["groupName"]
+                        )
+                    )
                     self._destroy()
                     return
                 else:
                     raise error
 
             rules = []
+
             def generate_rule(rule):
                 # FIXME note that we're forcing sg name to None here
                 # as it causes InvalidParameterCombination errors
@@ -75,19 +87,19 @@ class EC2RDSDbSecurityGroupState(nixops.resources.DiffEngineResourceState, EC2Co
                 # and we run nixops check as it will persist the id
                 # instead.
                 return {
-                    'securityGroupId': rule.get('EC2SecurityGroupId', None),
-                    'securityGroupName': None,
-                    'securityGroupOwnerId': rule.get('EC2SecurityGroupOwnerId', None),
-                    'cidrIp': rule.get('CIDRIP', None)
+                    "securityGroupId": rule.get("EC2SecurityGroupId", None),
+                    "securityGroupName": None,
+                    "securityGroupOwnerId": rule.get("EC2SecurityGroupOwnerId", None),
+                    "cidrIp": rule.get("CIDRIP", None),
                 }
 
-            for rule in response['DBSecurityGroups'][0].get('EC2SecurityGroups', []):
+            for rule in response["DBSecurityGroups"][0].get("EC2SecurityGroups", []):
                 rules.append(generate_rule(rule))
-            for rule in response['DBSecurityGroups'][0].get('IPRanges', []):
+            for rule in response["DBSecurityGroups"][0].get("IPRanges", []):
                 rules.append(generate_rule(rule))
 
             with self.depl._db:
-                self._state['rules'] = rules
+                self._state["rules"] = rules
 
     def realize_create_sg(self, allow_recreate):
         config = self.get_defn()
@@ -95,70 +107,91 @@ class EC2RDSDbSecurityGroupState(nixops.resources.DiffEngineResourceState, EC2Co
             if not allow_recreate:
                 raise Exception(
                     "RDS security group {} definition changed and it needs to be recreated"
-                    " use --allow-recreate if you want to create a new one"
-                    .format(self._state['groupName']))
+                    " use --allow-recreate if you want to create a new one".format(
+                        self._state["groupName"]
+                    )
+                )
 
             self.warn("RDS security group definition changed, recreating ...")
             self._destroy()
-            self.reset_client() #FIXME ideally this should be detected automatically
+            self.reset_client()  # FIXME ideally this should be detected automatically
 
-        self.log("creating RDS security group {}".format(config['groupName']))
-        self._state['region'] = config['region']
+        self.log("creating RDS security group {}".format(config["groupName"]))
+        self._state["region"] = config["region"]
         self.get_client("rds").create_db_security_group(
-            DBSecurityGroupName=config['groupName'],
-            DBSecurityGroupDescription=config['description'])
+            DBSecurityGroupName=config["groupName"],
+            DBSecurityGroupDescription=config["description"],
+        )
         with self.depl._db:
             self.state = self.UP
-            self._state['groupName'] = config['groupName']
-            self._state['description'] = config['description']
+            self._state["groupName"] = config["groupName"]
+            self._state["description"] = config["description"]
 
     def realize_rules_change(self, allow_recreate):
         config = self.get_defn()
 
-        rules_to_remove = [r for r in self._state.get('rules', []) if r not in config['rules']]
-        rules_to_add = [r for r in config['rules'] if r not in self._state.get('rules', [])]
+        rules_to_remove = [
+            r for r in self._state.get("rules", []) if r not in config["rules"]
+        ]
+        rules_to_add = [
+            r for r in config["rules"] if r not in self._state.get("rules", [])
+        ]
 
         for rule in rules_to_remove:
-            self.log("removing old rules from RDS security group {} ...".format(self._state['groupName']))
+            self.log(
+                "removing old rules from RDS security group {} ...".format(
+                    self._state["groupName"]
+                )
+            )
             kwargs = self.process_rule(rule)
             self.get_client("rds").revoke_db_security_group_ingress(**kwargs)
 
         for rule in rules_to_add:
-            self.log("adding new rules to RDS security group {} ...".format(self._state['groupName']))
+            self.log(
+                "adding new rules to RDS security group {} ...".format(
+                    self._state["groupName"]
+                )
+            )
             kwargs = self.process_rule(rule)
             self.get_client("rds").authorize_db_security_group_ingress(**kwargs)
 
         with self.depl._db:
-            self._state['rules'] = config['rules']
+            self._state["rules"] = config["rules"]
 
     def process_rule(self, config):
         # FIXME do more checks before passing the args to the boto api call
         args = dict()
-        args['DBSecurityGroupName'] = self._state['groupName']
-        args['CIDRIP'] = config.get('cidrIp', None)
-        args['EC2SecurityGroupName'] = config.get('securityGroupName', None)
-        args['EC2SecurityGroupId'] = config.get('securityGroupId', None)
-        args['EC2SecurityGroupOwnerId'] = config.get('securityGroupOwnerId', None)
-        return {attr : args[attr] for attr in args if args[attr] is not None}
+        args["DBSecurityGroupName"] = self._state["groupName"]
+        args["CIDRIP"] = config.get("cidrIp", None)
+        args["EC2SecurityGroupName"] = config.get("securityGroupName", None)
+        args["EC2SecurityGroupId"] = config.get("securityGroupId", None)
+        args["EC2SecurityGroupOwnerId"] = config.get("securityGroupOwnerId", None)
+        return {attr: args[attr] for attr in args if args[attr] is not None}
 
     def _destroy(self):
         if self.state != self.UP:
             return
-        self.log("destroying rds db security group {}".format(self._state['groupName']))
+        self.log("destroying rds db security group {}".format(self._state["groupName"]))
         try:
-            self.get_client("rds").delete_db_security_group(DBSecurityGroupName=self._state['groupName'])
+            self.get_client("rds").delete_db_security_group(
+                DBSecurityGroupName=self._state["groupName"]
+            )
         except botocore.exceptions.ClientError as error:
-            if error.response['Error']['Code'] == 'DBSecurityGroupNotFound':
-                self.warn("rds security group {} already deleted".format(self._state['groupName']))
+            if error.response["Error"]["Code"] == "DBSecurityGroupNotFound":
+                self.warn(
+                    "rds security group {} already deleted".format(
+                        self._state["groupName"]
+                    )
+                )
             else:
                 raise error
 
         with self.depl._db:
             self.state = self.MISSING
-            self._state['groupName'] = None
-            self._state['region'] = None
-            self._state['description'] = None
-            self._state['rules'] = None
+            self._state["groupName"] = None
+            self._state["region"] = None
+            self._state["description"] = None
+            self._state["rules"] = None
 
     def destroy(self, wipe=True):
         self._destroy()

--- a/nixopsaws/resources/ec2_security_group.py
+++ b/nixopsaws/resources/ec2_security_group.py
@@ -7,6 +7,7 @@ import nixops.resources
 import nixops.util
 import nixopsaws.ec2_utils
 
+
 class EC2SecurityGroupDefinition(nixops.resources.ResourceDefinition):
     """Definition of an EC2 security group."""
 
@@ -20,10 +21,16 @@ class EC2SecurityGroupDefinition(nixops.resources.ResourceDefinition):
 
     def __init__(self, xml):
         super(EC2SecurityGroupDefinition, self).__init__(xml)
-        self.security_group_name = xml.find("attrs/attr[@name='name']/string").get("value")
-        self.security_group_description = xml.find("attrs/attr[@name='description']/string").get("value")
+        self.security_group_name = xml.find("attrs/attr[@name='name']/string").get(
+            "value"
+        )
+        self.security_group_description = xml.find(
+            "attrs/attr[@name='description']/string"
+        ).get("value")
         self.region = xml.find("attrs/attr[@name='region']/string").get("value")
-        self.access_key_id = xml.find("attrs/attr[@name='accessKeyId']/string").get("value")
+        self.access_key_id = xml.find("attrs/attr[@name='accessKeyId']/string").get(
+            "value"
+        )
 
         self.vpc_id = None
         if not xml.find("attrs/attr[@name='vpcId']/string") is None:
@@ -33,22 +40,36 @@ class EC2SecurityGroupDefinition(nixops.resources.ResourceDefinition):
         for rule_xml in xml.findall("attrs/attr[@name='rules']/list/attrs"):
             ip_protocol = rule_xml.find("attr[@name='protocol']/string").get("value")
             if ip_protocol == "icmp":
-                from_port = int(rule_xml.find("attr[@name='typeNumber']/int").get("value"))
-                to_port = int(rule_xml.find("attr[@name='codeNumber']/int").get("value"))
+                from_port = int(
+                    rule_xml.find("attr[@name='typeNumber']/int").get("value")
+                )
+                to_port = int(
+                    rule_xml.find("attr[@name='codeNumber']/int").get("value")
+                )
             else:
-                from_port = int(rule_xml.find("attr[@name='fromPort']/int").get("value"))
+                from_port = int(
+                    rule_xml.find("attr[@name='fromPort']/int").get("value")
+                )
                 to_port = int(rule_xml.find("attr[@name='toPort']/int").get("value"))
             cidr_ip_xml = rule_xml.find("attr[@name='sourceIp']/string")
             if not cidr_ip_xml is None:
-                self.security_group_rules.append([ ip_protocol, from_port, to_port, cidr_ip_xml.get("value") ])
+                self.security_group_rules.append(
+                    [ip_protocol, from_port, to_port, cidr_ip_xml.get("value")]
+                )
             else:
-                group_name = rule_xml.find("attr[@name='sourceGroup']/attrs/attr[@name='groupName']/string").get("value")
-                owner_id = rule_xml.find("attr[@name='sourceGroup']/attrs/attr[@name='ownerId']/string").get("value")
-                self.security_group_rules.append([ ip_protocol, from_port, to_port, group_name, owner_id ])
-
+                group_name = rule_xml.find(
+                    "attr[@name='sourceGroup']/attrs/attr[@name='groupName']/string"
+                ).get("value")
+                owner_id = rule_xml.find(
+                    "attr[@name='sourceGroup']/attrs/attr[@name='ownerId']/string"
+                ).get("value")
+                self.security_group_rules.append(
+                    [ip_protocol, from_port, to_port, group_name, owner_id]
+                )
 
     def show_type(self):
         return "{0} [{1}]".format(self.get_type(), self.region)
+
 
 class EC2SecurityGroupState(nixops.resources.ResourceState):
     """State of an EC2 security group."""
@@ -56,9 +77,13 @@ class EC2SecurityGroupState(nixops.resources.ResourceState):
     region = nixops.util.attr_property("ec2.region", None)
     security_group_id = nixops.util.attr_property("ec2.securityGroupId", None)
     security_group_name = nixops.util.attr_property("ec2.securityGroupName", None)
-    security_group_description = nixops.util.attr_property("ec2.securityGroupDescription", None)
-    security_group_rules = nixops.util.attr_property("ec2.securityGroupRules", [], 'json')
-    old_security_groups = nixops.util.attr_property("ec2.oldSecurityGroups", [], 'json')
+    security_group_description = nixops.util.attr_property(
+        "ec2.securityGroupDescription", None
+    )
+    security_group_rules = nixops.util.attr_property(
+        "ec2.securityGroupRules", [], "json"
+    )
+    old_security_groups = nixops.util.attr_property("ec2.oldSecurityGroups", [], "json")
     access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
     vpc_id = nixops.util.attr_property("ec2.vpcId", None)
 
@@ -72,14 +97,15 @@ class EC2SecurityGroupState(nixops.resources.ResourceState):
 
     def show_type(self):
         s = super(EC2SecurityGroupState, self).show_type()
-        if self.region: s = "{0} [{1}]".format(s, self.region)
+        if self.region:
+            s = "{0} [{1}]".format(s, self.region)
         return s
 
     def prefix_definition(self, attr):
-        return {('resources', 'ec2SecurityGroups'): attr}
+        return {("resources", "ec2SecurityGroups"): attr}
 
     def get_physical_spec(self):
-        return {'groupId': self.security_group_id}
+        return {"groupId": self.security_group_id}
 
     @property
     def resource_id(self):
@@ -87,33 +113,43 @@ class EC2SecurityGroupState(nixops.resources.ResourceState):
 
     def create_after(self, resources, defn):
         #!!! TODO: Handle dependencies between security groups
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.vpc.VPCState) or
-                isinstance(r, nixopsaws.resources.elastic_ip.ElasticIPState)
-               }
+        return {
+            r
+            for r in resources
+            if isinstance(r, nixopsaws.resources.vpc.VPCState)
+            or isinstance(r, nixopsaws.resources.elastic_ip.ElasticIPState)
+        }
 
     def _connect(self):
-        if self._conn: return
+        if self._conn:
+            return
         self._conn = nixopsaws.ec2_utils.connect(self.region, self.access_key_id)
 
     def create(self, defn, check, allow_reboot, allow_recreate):
         def retry_notfound(f):
-            nixopsaws.ec2_utils.retry(f, error_codes=['InvalidGroup.NotFound'])
+            nixopsaws.ec2_utils.retry(f, error_codes=["InvalidGroup.NotFound"])
 
         # Name or region change means a completely new security group
-        if self.security_group_name and (defn.security_group_name != self.security_group_name or defn.region != self.region):
+        if self.security_group_name and (
+            defn.security_group_name != self.security_group_name
+            or defn.region != self.region
+        ):
             with self.depl._db:
                 self.state = self.UNKNOWN
-                self.old_security_groups = self.old_security_groups + [{'name': self.security_group_name, 'region': self.region}]
+                self.old_security_groups = self.old_security_groups + [
+                    {"name": self.security_group_name, "region": self.region}
+                ]
 
         if defn.vpc_id is not None:
             if defn.vpc_id.startswith("res-"):
                 res = self.depl.get_typed_resource(defn.vpc_id[4:].split(".")[0], "vpc")
-                defn.vpc_id = res._state['vpcId']
+                defn.vpc_id = res._state["vpcId"]
 
         with self.depl._db:
             self.region = defn.region
-            self.access_key_id = defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+            self.access_key_id = (
+                defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+            )
             self.security_group_name = defn.security_group_name
             self.security_group_description = defn.security_group_description
             self.vpc_id = defn.vpc_id
@@ -125,26 +161,40 @@ class EC2SecurityGroupState(nixops.resources.ResourceState):
 
                 try:
                     if self.vpc_id:
-                        grp = self._conn.get_all_security_groups(group_ids=[ self.security_group_id ])[0]
+                        grp = self._conn.get_all_security_groups(
+                            group_ids=[self.security_group_id]
+                        )[0]
                     else:
-                        grp = self._conn.get_all_security_groups([ defn.security_group_name ])[0]
+                        grp = self._conn.get_all_security_groups(
+                            [defn.security_group_name]
+                        )[0]
                     self.state = self.UP
                     self.security_group_id = grp.id
                     self.security_group_description = grp.description
                     rules = []
                     for rule in grp.rules:
                         for grant in rule.grants:
-                            new_rule = [ rule.ip_protocol, int(rule.from_port), int(rule.to_port) ]
+                            new_rule = [
+                                rule.ip_protocol,
+                                int(rule.from_port),
+                                int(rule.to_port),
+                            ]
                             if grant.cidr_ip:
                                 new_rule.append(grant.cidr_ip)
                             else:
-                                group  = nixopsaws.ec2_utils.id_to_security_group_name(self._conn, grant.groupId, self.vpc_id) if self.vpc_id else grant.groupName
+                                group = (
+                                    nixopsaws.ec2_utils.id_to_security_group_name(
+                                        self._conn, grant.groupId, self.vpc_id
+                                    )
+                                    if self.vpc_id
+                                    else grant.groupName
+                                )
                                 new_rule.append(group)
                                 new_rule.append(grant.owner_id)
                             rules.append(new_rule)
                     self.security_group_rules = rules
                 except boto.exception.EC2ResponseError as e:
-                    if e.error_code == u'InvalidGroup.NotFound':
+                    if e.error_code == u"InvalidGroup.NotFound":
                         self.state = self.MISSING
                     else:
                         raise
@@ -154,23 +204,34 @@ class EC2SecurityGroupState(nixops.resources.ResourceState):
         for rule in defn.security_group_rules:
             if rule[-1].startswith("res-"):
                 res = self.depl.get_typed_resource(rule[-1][4:], "elastic-ip")
-                rule[-1] = res.public_ipv4 + '/32'
+                rule[-1] = res.public_ipv4 + "/32"
             resolved_security_group_rules.append(rule)
 
         security_group_was_created = False
         if self.state == self.MISSING or self.state == self.UNKNOWN:
             self._connect()
             try:
-                self.logger.log("creating EC2 security group ‘{0}’...".format(self.security_group_name))
-                grp = self._conn.create_security_group(self.security_group_name, self.security_group_description, defn.vpc_id)
+                self.logger.log(
+                    "creating EC2 security group ‘{0}’...".format(
+                        self.security_group_name
+                    )
+                )
+                grp = self._conn.create_security_group(
+                    self.security_group_name,
+                    self.security_group_description,
+                    defn.vpc_id,
+                )
                 self.security_group_id = grp.id
                 # If group creation succeeded, the group wasn't there before,
                 # in which case also its rules must be (re-)created below.
                 security_group_was_created = True
             except boto.exception.EC2ResponseError as e:
-                if self.state != self.UNKNOWN or e.error_code != u'InvalidGroup.Duplicate':
+                if (
+                    self.state != self.UNKNOWN
+                    or e.error_code != u"InvalidGroup.Duplicate"
+                ):
                     raise
-            self.state = self.STARTING #ugh
+            self.state = self.STARTING  # ugh
 
         new_rules = set()
         old_rules = set()
@@ -185,80 +246,126 @@ class EC2SecurityGroupState(nixops.resources.ResourceState):
                 old_rules.remove(tupled_rule)
 
         if new_rules:
-            self.logger.log("adding new rules to EC2 security group ‘{0}’...".format(self.security_group_name))
+            self.logger.log(
+                "adding new rules to EC2 security group ‘{0}’...".format(
+                    self.security_group_name
+                )
+            )
             if grp is None:
                 self._connect()
                 grp = self.get_security_group()
             for rule in new_rules:
                 try:
                     if len(rule) == 4:
-                        retry_notfound(lambda: grp.authorize(ip_protocol=rule[0], from_port=rule[1], to_port=rule[2], cidr_ip=rule[3]))
+                        retry_notfound(
+                            lambda: grp.authorize(
+                                ip_protocol=rule[0],
+                                from_port=rule[1],
+                                to_port=rule[2],
+                                cidr_ip=rule[3],
+                            )
+                        )
                     else:
                         args = {}
-                        args['owner_id']=rule[4]
+                        args["owner_id"] = rule[4]
                         if self.vpc_id:
-                            args['id']=nixopsaws.ec2_utils.name_to_security_group(self._conn, rule[3], self.vpc_id)
+                            args["id"] = nixopsaws.ec2_utils.name_to_security_group(
+                                self._conn, rule[3], self.vpc_id
+                            )
                         else:
-                            args['name']=rule[3]
+                            args["name"] = rule[3]
                         src_group = boto.ec2.securitygroup.SecurityGroup(**args)
-                        retry_notfound(lambda: grp.authorize(ip_protocol=rule[0], from_port=rule[1], to_port=rule[2], src_group=src_group))
+                        retry_notfound(
+                            lambda: grp.authorize(
+                                ip_protocol=rule[0],
+                                from_port=rule[1],
+                                to_port=rule[2],
+                                src_group=src_group,
+                            )
+                        )
                 except boto.exception.EC2ResponseError as e:
-                    if e.error_code != u'InvalidPermission.Duplicate':
+                    if e.error_code != u"InvalidPermission.Duplicate":
                         raise
 
         if old_rules:
-            self.logger.log("removing old rules from EC2 security group ‘{0}’...".format(self.security_group_name))
+            self.logger.log(
+                "removing old rules from EC2 security group ‘{0}’...".format(
+                    self.security_group_name
+                )
+            )
             if grp is None:
                 self._connect()
                 grp = self.get_security_group()
             for rule in old_rules:
                 if len(rule) == 4:
-                    grp.revoke(ip_protocol=rule[0], from_port=rule[1], to_port=rule[2], cidr_ip=rule[3])
+                    grp.revoke(
+                        ip_protocol=rule[0],
+                        from_port=rule[1],
+                        to_port=rule[2],
+                        cidr_ip=rule[3],
+                    )
                 else:
                     args = {}
-                    args['owner_id']=rule[4]
+                    args["owner_id"] = rule[4]
                     if self.vpc_id:
-                        args['id']=nixopsaws.ec2_utils.name_to_security_group(self._conn, rule[3], self.vpc_id)
+                        args["id"] = nixopsaws.ec2_utils.name_to_security_group(
+                            self._conn, rule[3], self.vpc_id
+                        )
                     else:
-                        args['name']=rule[3]
+                        args["name"] = rule[3]
                     src_group = boto.ec2.securitygroup.SecurityGroup(**args)
-                    grp.revoke(ip_protocol=rule[0], from_port=rule[1], to_port=rule[2], src_group=src_group)
+                    grp.revoke(
+                        ip_protocol=rule[0],
+                        from_port=rule[1],
+                        to_port=rule[2],
+                        src_group=src_group,
+                    )
         self.security_group_rules = resolved_security_group_rules
 
         self.state = self.UP
 
     def get_security_group(self):
         if self.vpc_id:
-            return self._conn.get_all_security_groups(group_ids=[ self.security_group_id ])[0]
+            return self._conn.get_all_security_groups(
+                group_ids=[self.security_group_id]
+            )[0]
         else:
-            return self._conn.get_all_security_groups(groupnames=[ self.security_group_name ])[0]
+            return self._conn.get_all_security_groups(
+                groupnames=[self.security_group_name]
+            )[0]
 
     def after_activation(self, defn):
         region = self.region
         self._connect()
         conn = self._conn
         for group in self.old_security_groups:
-            if group['region'] != region:
-                region = group['region']
+            if group["region"] != region:
+                region = group["region"]
                 conn = nixopsaws.ec2_utils.connect(region, self.access_key_id)
             try:
-                conn.delete_security_group(group['name'])
+                conn.delete_security_group(group["name"])
             except boto.exception.EC2ResponseError as e:
-                if e.error_code != u'InvalidGroup.NotFound':
+                if e.error_code != u"InvalidGroup.NotFound":
                     raise
         self.old_security_groups = []
 
     def destroy(self, wipe=False):
         if self.state == self.UP or self.state == self.STARTING:
-            self.logger.log("deleting EC2 security group `{0}' ID `{1}'...".format(
-                self.security_group_name, self.security_group_id))
+            self.logger.log(
+                "deleting EC2 security group `{0}' ID `{1}'...".format(
+                    self.security_group_name, self.security_group_id
+                )
+            )
             self._connect()
             try:
                 nixopsaws.ec2_utils.retry(
-                    lambda: self._conn.delete_security_group(group_id=self.security_group_id),
-                    error_codes=['DependencyViolation'])
+                    lambda: self._conn.delete_security_group(
+                        group_id=self.security_group_id
+                    ),
+                    error_codes=["DependencyViolation"],
+                )
             except boto.exception.EC2ResponseError as e:
-                if e.error_code != u'InvalidGroup.NotFound':
+                if e.error_code != u"InvalidGroup.NotFound":
                     raise
 
             self.state = self.MISSING

--- a/nixopsaws/resources/efs_common.py
+++ b/nixopsaws/resources/efs_common.py
@@ -1,17 +1,24 @@
 import boto3
 import nixopsaws.ec2_utils
 
-class EFSCommonState():
+
+class EFSCommonState:
 
     _client = None
 
     def _get_client(self, access_key_id=None, region=None):
-        if self._client: return self._client
+        if self._client:
+            return self._client
 
-        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(access_key_id or self.access_key_id)
+        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(
+            access_key_id or self.access_key_id
+        )
 
-        self._client = boto3.session.Session().client('efs', region_name=region or self.region, \
-                                                     aws_access_key_id=access_key_id, \
-                                                     aws_secret_access_key=secret_access_key)
+        self._client = boto3.session.Session().client(
+            "efs",
+            region_name=region or self.region,
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+        )
 
         return self._client

--- a/nixopsaws/resources/elastic_ip.py
+++ b/nixopsaws/resources/elastic_ip.py
@@ -27,7 +27,9 @@ class ElasticIPDefinition(nixops.resources.ResourceDefinition):
 class ElasticIPState(nixops.resources.ResourceState):
     """State of an EC2 elastic IP address."""
 
-    state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.ResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
     region = nixops.util.attr_property("ec2.region", None)
     public_ipv4 = nixops.util.attr_property("ec2.ipv4", None)
@@ -44,7 +46,8 @@ class ElasticIPState(nixops.resources.ResourceState):
 
     def show_type(self):
         s = super(ElasticIPState, self).show_type()
-        if self.state == self.UP: s = "{0} [{1}]".format(s, self.region)
+        if self.state == self.UP:
+            s = "{0} [{1}]".format(s, self.region)
         return s
 
     @property
@@ -54,34 +57,47 @@ class ElasticIPState(nixops.resources.ResourceState):
     def get_physical_spec(self):
         physical = {}
         if self.public_ipv4:
-            physical['address'] = self.public_ipv4
+            physical["address"] = self.public_ipv4
         return physical
 
     def prefix_definition(self, attr):
-        return {('resources', 'elasticIPs'): attr}
+        return {("resources", "elasticIPs"): attr}
 
     def connect_boto3(self, region):
-        if self._conn_boto3: return self._conn_boto3
-        self._conn_boto3 = nixops.ec2_utils.connect_ec2_boto3(region, self.access_key_id)
+        if self._conn_boto3:
+            return self._conn_boto3
+        self._conn_boto3 = nixops.ec2_utils.connect_ec2_boto3(
+            region, self.access_key_id
+        )
         return self._conn_boto3
 
     def create(self, defn, check, allow_reboot, allow_recreate):
 
-        self.access_key_id = defn.config['accessKeyId'] or nixopsaws.ec2_utils.get_access_key_id()
+        self.access_key_id = (
+            defn.config["accessKeyId"] or nixopsaws.ec2_utils.get_access_key_id()
+        )
         if not self.access_key_id:
-            raise Exception("please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID")
+            raise Exception(
+                "please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID"
+            )
 
-        if self.state == self.UP and (self.region != defn.config['region']):
-            raise Exception("changing the region of an elastic IP address is not supported")
+        if self.state == self.UP and (self.region != defn.config["region"]):
+            raise Exception(
+                "changing the region of an elastic IP address is not supported"
+            )
 
         if self.state != self.UP:
 
-            self.connect_boto3(defn.config['region'])
+            self.connect_boto3(defn.config["region"])
 
-            is_vpc = defn.config['vpc']
-            domain = 'vpc' if is_vpc else 'standard'
+            is_vpc = defn.config["vpc"]
+            domain = "vpc" if is_vpc else "standard"
 
-            self.log("creating elastic IP address (region ‘{0}’ - domain ‘{1}’)...".format(defn.config['region'],domain))
+            self.log(
+                "creating elastic IP address (region ‘{0}’ - domain ‘{1}’)...".format(
+                    defn.config["region"], domain
+                )
+            )
             address = self._conn_boto3.allocate_address(Domain=domain)
 
             # FIXME: if we crash before the next step, we forget the
@@ -90,10 +106,10 @@ class ElasticIPState(nixops.resources.ResourceState):
 
             with self.depl._db:
                 self.state = self.UP
-                self.region = defn.config['region']
-                self.public_ipv4 = address['PublicIp']
+                self.region = defn.config["region"]
+                self.public_ipv4 = address["PublicIp"]
                 if is_vpc:
-                    self.allocation_id = address['AllocationId']
+                    self.allocation_id = address["AllocationId"]
                 self.vpc = is_vpc
 
             self.log("IP address is {0}".format(self.public_ipv4))
@@ -102,15 +118,15 @@ class ElasticIPState(nixops.resources.ResourceState):
         try:
             response = self._conn_boto3.describe_addresses(PublicIps=[self.public_ipv4])
         except botocore.exceptions.ClientError as error:
-            if error.response['Error']['Code'] == "InvalidAddress.NotFound":
+            if error.response["Error"]["Code"] == "InvalidAddress.NotFound":
                 self.warn("public IP {} was deleted".format(self.public_ipv4))
                 return None
             else:
                 raise error
-        if len(response['Addresses']) == 0:
+        if len(response["Addresses"]) == 0:
             self.warn("public IP {} was deleted".format(self.public_ipv4))
             return None
-        return response['Addresses'][0]
+        return response["Addresses"][0]
 
     def check(self):
         self.connect_boto3(self.region)
@@ -123,17 +139,22 @@ class ElasticIPState(nixops.resources.ResourceState):
             self.connect_boto3(self.region)
             eip = self.describe_eip()
             if eip is not None:
-                vpc = (eip.get('Domain', None) == 'vpc')
-                if 'AssociationId' in eip.keys():
-                    self.log("disassociating elastic ip {0} with assocation ID {1}".format(
-                        eip['PublicIp'], eip['AssociationId']))
+                vpc = eip.get("Domain", None) == "vpc"
+                if "AssociationId" in eip.keys():
+                    self.log(
+                        "disassociating elastic ip {0} with assocation ID {1}".format(
+                            eip["PublicIp"], eip["AssociationId"]
+                        )
+                    )
                     if vpc:
-                        self._conn_boto3.disassociate_address(AssociationId=eip['AssociationId'])
-                self.log("releasing elastic IP {}".format(eip['PublicIp']))
+                        self._conn_boto3.disassociate_address(
+                            AssociationId=eip["AssociationId"]
+                        )
+                self.log("releasing elastic IP {}".format(eip["PublicIp"]))
                 if vpc == True:
-                    self._conn_boto3.release_address(AllocationId=eip['AllocationId'])
+                    self._conn_boto3.release_address(AllocationId=eip["AllocationId"])
                 else:
-                    self._conn_boto3.release_address(PublicIp=eip['PublicIp'])
+                    self._conn_boto3.release_address(PublicIp=eip["PublicIp"])
 
             with self.depl._db:
                 self.state = self.MISSING

--- a/nixopsaws/resources/iam_role.py
+++ b/nixopsaws/resources/iam_role.py
@@ -12,11 +12,14 @@ from xml.etree import ElementTree
 from pprint import pprint
 from boto.exception import BotoServerError
 
+
 class IamPermissionException(BotoServerError):
     pass
 
+
 class IamNotFound(BotoServerError):
     pass
+
 
 class IAMRoleDefinition(nixops.resources.ResourceDefinition):
     """Definition of an IAM Role."""
@@ -32,9 +35,13 @@ class IAMRoleDefinition(nixops.resources.ResourceDefinition):
     def __init__(self, xml):
         nixops.resources.ResourceDefinition.__init__(self, xml)
         self.role_name = xml.find("attrs/attr[@name='name']/string").get("value")
-        self.access_key_id = xml.find("attrs/attr[@name='accessKeyId']/string").get("value")
+        self.access_key_id = xml.find("attrs/attr[@name='accessKeyId']/string").get(
+            "value"
+        )
         self.policy = xml.find("attrs/attr[@name='policy']/string").get("value")
-        self.assume_role_policy = xml.find("attrs/attr[@name='assumeRolePolicy']/string").get("value")
+        self.assume_role_policy = xml.find(
+            "attrs/attr[@name='assumeRolePolicy']/string"
+        ).get("value")
 
     def show_type(self):
         return "{0}".format(self.get_type())
@@ -43,7 +50,9 @@ class IAMRoleDefinition(nixops.resources.ResourceDefinition):
 class IAMRoleState(nixops.resources.ResourceState):
     """State of an IAM Role."""
 
-    state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.ResourceState.MISSING, int
+    )
     role_name = nixops.util.attr_property("ec2.roleName", None)
     access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
     policy = nixops.util.attr_property("ec2.policy", None)
@@ -53,35 +62,34 @@ class IAMRoleState(nixops.resources.ResourceState):
     def get_type(cls):
         return "iam-role"
 
-
     def __init__(self, depl, name, id):
         nixops.resources.ResourceState.__init__(self, depl, name, id)
         self._conn = None
-
 
     def show_type(self):
         s = super(IAMRoleState, self).show_type()
         return s
 
-
     @property
     def resource_id(self):
         return self.role_name
 
-
     def get_definition_prefix(self):
         return "resources.iamRoles."
 
-
     def connect(self):
-        if self._conn: return
-        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(self.access_key_id)
+        if self._conn:
+            return
+        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(
+            self.access_key_id
+        )
         self._conn = boto.connect_iam(
-            aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
-
+            aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key
+        )
 
     def _destroy(self):
-        if self.state != self.UP: return
+        if self.state != self.UP:
+            return
         self.connect()
 
         try:
@@ -90,7 +98,9 @@ class IAMRoleState(nixops.resources.ResourceState):
                 self._get_instance_profile(self.role_name)
                 self._get_role(self.role_name)
                 # sever the link
-                self._conn.remove_role_from_instance_profile(self.role_name, self.role_name)
+                self._conn.remove_role_from_instance_profile(
+                    self.role_name, self.role_name
+                )
             except IamPermissionException as e:
                 self.log(str(e))
                 raise
@@ -141,15 +151,14 @@ class IAMRoleState(nixops.resources.ResourceState):
         except IamPermissionException:
             raise
         except IamNotFound:
-            self.warn("instance profile already destroyed");
+            self.warn("instance profile already destroyed")
         except BotoServerError as e:
-                if e.status == 404:
-                    self.warn("instance profile already removed")
+            if e.status == 404:
+                self.warn("instance profile already removed")
 
         except Exception as e:
             self.log(str(e))
             raise
-
 
         with self.depl._db:
             self.state = self.MISSING
@@ -158,63 +167,65 @@ class IAMRoleState(nixops.resources.ResourceState):
             self.policy = None
             self.assume_role_policy = None
 
-
     def create_after(self, resources, defn):
         # IAM roles can refer to S3 buckets.
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.s3_bucket.S3BucketState)}
+        return {
+            r
+            for r in resources
+            if isinstance(r, nixopsaws.resources.s3_bucket.S3BucketState)
+        }
 
-
-    def _get_instance_profile(self, name, allow404 = True):
+    def _get_instance_profile(self, name, allow404=True):
         try:
             return self._conn.get_instance_profile(name)
         except BotoServerError as e:
             if e.status == 403:
-                raise IamPermissionException(e.status, e.reason, body = e.body)
+                raise IamPermissionException(e.status, e.reason, body=e.body)
             if e.status == 404:
                 if allow404:
                     return False
                 else:
-                    raise IamNotFound(e.status, e.reason, body = e.body)
+                    raise IamNotFound(e.status, e.reason, body=e.body)
         except:
             raise
 
-
-    def _get_role_policy(self, name, allow404 = True):
+    def _get_role_policy(self, name, allow404=True):
         try:
             return self._conn.get_role_policy(name, name)
         except BotoServerError as e:
             if e.status == 403:
-                raise IamPermissionException(e.status, e.reason, body = e.body)
+                raise IamPermissionException(e.status, e.reason, body=e.body)
             if e.status == 404:
                 if allow404:
                     return False
                 else:
-                    raise IamNotFound(e.status, e.reason, body = e.body)
+                    raise IamNotFound(e.status, e.reason, body=e.body)
         except:
             raise
 
-
-    def _get_role(self, name, allow404 = True):
+    def _get_role(self, name, allow404=True):
         try:
             return self._conn.get_role(name)
         except BotoServerError as e:
             if e.status == 403:
-                raise IamPermissionException(e.status, e.reason, body = e.body)
+                raise IamPermissionException(e.status, e.reason, body=e.body)
             if e.status == 404:
                 if allow404:
                     return False
                 else:
-                    raise IamNotFound(e.status, e.reason, body = e.body)
+                    raise IamNotFound(e.status, e.reason, body=e.body)
         except:
             raise
 
-
     def create(self, defn, check, allow_reboot, allow_recreate):
 
-        self.access_key_id = defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+        self.access_key_id = (
+            defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+        )
         if not self.access_key_id:
-            raise Exception("please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID")
+            raise Exception(
+                "please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID"
+            )
 
         self.connect()
 
@@ -228,20 +239,21 @@ class IAMRoleState(nixops.resources.ResourceState):
 
         if not ip:
             self.log("creating IAM instance profile ‘{0}’...".format(defn.role_name))
-            self._conn.create_instance_profile(defn.role_name, '/')
+            self._conn.create_instance_profile(defn.role_name, "/")
             self._conn.add_role_to_instance_profile(defn.role_name, defn.role_name)
 
         if not check:
             self._conn.put_role_policy(defn.role_name, defn.role_name, defn.policy)
 
         if defn.assume_role_policy != "":
-            self._conn.update_assume_role_policy(defn.role_name, defn.assume_role_policy)
+            self._conn.update_assume_role_policy(
+                defn.role_name, defn.assume_role_policy
+            )
 
         with self.depl._db:
             self.state = self.UP
             self.role_name = defn.role_name
             self.policy = defn.policy
-
 
     def destroy(self, wipe=False):
         self._destroy()

--- a/nixopsaws/resources/route53_health_check.py
+++ b/nixopsaws/resources/route53_health_check.py
@@ -13,7 +13,8 @@ import nixopsaws.ec2_utils
 from pprint import pprint
 import copy
 
-#boto3.set_stream_logger(name='botocore')
+# boto3.set_stream_logger(name='botocore')
+
 
 class Route53HealthCheckDefinition(nixops.resources.ResourceDefinition):
     """Definition of an Route53 Health Check."""
@@ -44,18 +45,24 @@ class Route53HealthCheckDefinition(nixops.resources.ResourceDefinition):
         self.alarm_indentifier_region = config["alarmIdentifier"]["region"]
         self.alarm_indentifier_name = config["alarmIdentifier"]["name"]
         self.insufficient_data_health_status = config["insufficientDataHealthStatus"]
-        self.child_health_checks = config['childHealthChecks']
-        self.health_threshold = config['healthThreshold']
+        self.child_health_checks = config["childHealthChecks"]
+        self.health_threshold = config["healthThreshold"]
 
 
 class Route53HealthCheckState(nixops.resources.ResourceState):
     """State of a Route53 Health Check."""
 
-    state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.ResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
     health_check_id = nixops.util.attr_property("route53.healthCheckId", None)
-    health_check_config = nixops.util.attr_property("route53.healthCheckConfig", {}, "json")
-    child_health_checks = nixops.util.attr_property("route53.childHealthChecks", [], "json")
+    health_check_config = nixops.util.attr_property(
+        "route53.healthCheckConfig", {}, "json"
+    )
+    child_health_checks = nixops.util.attr_property(
+        "route53.childHealthChecks", [], "json"
+    )
 
     @classmethod
     def get_type(cls):
@@ -70,79 +77,100 @@ class Route53HealthCheckState(nixops.resources.ResourceState):
         return self.health_check_id
 
     def prefix_definition(self, attr):
-        return {('resources', 'route53HealthChecks'): attr}
+        return {("resources", "route53HealthChecks"): attr}
 
     def boto_session(self):
         if self._boto_session is None:
-            (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(self.access_key_id)
+            (
+                access_key_id,
+                secret_access_key,
+            ) = nixopsaws.ec2_utils.fetch_aws_secret_key(self.access_key_id)
             self._boto_session = boto3.session.Session(
-                                               aws_access_key_id=access_key_id,
-                                               aws_secret_access_key=secret_access_key)
+                aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key
+            )
         return self._boto_session
 
     def resolve_health_check(self, id):
-        if id.startswith('res-'):
+        if id.startswith("res-"):
             hc = self.depl.get_typed_resource(id[4:], "aws-route53-health-check")
             if not hc.health_check_id:
-                raise Exception("cannot create calculated health check for not-yet children.")
+                raise Exception(
+                    "cannot create calculated health check for not-yet children."
+                )
             return hc.health_check_id
         else:
             return id
 
-
     def build_config(self, defn):
         def resolve_machine_ip(v):
-            if v.startswith('res-'):
+            if v.startswith("res-"):
                 m = self.depl.get_machine(v[4:])
                 if not m.public_ipv4:
-                    raise Exception("cannot create health check for a machine that has not yet been created")
+                    raise Exception(
+                        "cannot create health check for a machine that has not yet been created"
+                    )
                 return m.public_ipv4
             else:
                 return v
 
-        cfg = { 'Type': defn.type }
+        cfg = {"Type": defn.type}
         if defn.ip_address:
-            cfg['IPAddress'] = resolve_machine_ip(defn.ip_address)
+            cfg["IPAddress"] = resolve_machine_ip(defn.ip_address)
 
         if defn.fqdn:
-            cfg['FullyQualifiedDomainName'] = defn.fqdn
+            cfg["FullyQualifiedDomainName"] = defn.fqdn
         if defn.port:
-            cfg['Port'] = defn.port
+            cfg["Port"] = defn.port
         if defn.resource_path != "":
-            cfg['ResourcePath'] = defn.resource_path
+            cfg["ResourcePath"] = defn.resource_path
         if defn.search_string != "":
-            cfg['SearchString'] = defn.search_string
+            cfg["SearchString"] = defn.search_string
         if defn.regions != []:
-            cfg['Regions'] = defn.regions
+            cfg["Regions"] = defn.regions
         if defn.insufficient_data_health_status:
-            cfg['insufficientDataHealthStatus'] = defn.insufficient_data_health_status
+            cfg["insufficientDataHealthStatus"] = defn.insufficient_data_health_status
         if defn.alarm_indentifier_name:
-            cfg['AlarmIdentifier'] = { 'Name': defn.alarm_indentifier_name, 'Region': defn.alarm_indentifier_region };
+            cfg["AlarmIdentifier"] = {
+                "Name": defn.alarm_indentifier_name,
+                "Region": defn.alarm_indentifier_region,
+            }
 
         if defn.type == "CALCULATED":
-            cfg['ChildHealthChecks'] = map(self.resolve_health_check, defn.child_health_checks)
-            cfg['HealthThreshold'] = defn.health_threshold
+            cfg["ChildHealthChecks"] = map(
+                self.resolve_health_check, defn.child_health_checks
+            )
+            cfg["HealthThreshold"] = defn.health_threshold
         else:
-            cfg['RequestInterval'] = defn.request_interval
-            cfg['FailureThreshold'] = defn.failure_threshold
-            cfg['Inverted'] = defn.inverted
-            cfg['EnableSNI'] = defn.enable_sni
+            cfg["RequestInterval"] = defn.request_interval
+            cfg["FailureThreshold"] = defn.failure_threshold
+            cfg["Inverted"] = defn.inverted
+            cfg["EnableSNI"] = defn.enable_sni
 
         return cfg
 
     def create(self, defn, check, allow_reboot, allow_recreate):
-        self.access_key_id = defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
-        if not (self.access_key_id or os.environ['AWS_ACCESS_KEY_ID']):
+        self.access_key_id = (
+            defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+        )
+        if not (self.access_key_id or os.environ["AWS_ACCESS_KEY_ID"]):
             raise Exception("please set ‘accessKeyId’ or $AWS_ACCESS_KEY_ID")
 
         client = self.boto_session().client("route53")
 
         def cannot_change(desc, sk, d):
-            if self.health_check_config and sk in self.health_check_config and self.health_check_config[sk] != d:
-                raise Exception("{} of health check cannot be changed from {} to {}. Need to destroy before redeploying.".format(desc, self.health_check_config[sk], d))
+            if (
+                self.health_check_config
+                and sk in self.health_check_config
+                and self.health_check_config[sk] != d
+            ):
+                raise Exception(
+                    "{} of health check cannot be changed from {} to {}. Need to destroy before redeploying.".format(
+                        desc, self.health_check_config[sk], d
+                    )
+                )
 
-        cannot_change('type', 'Type', defn.type)
-        cannot_change('request interval', 'RequestInterval', defn.request_interval)
+        cannot_change("type", "Type", defn.type)
+        cannot_change("request interval", "RequestInterval", defn.request_interval)
 
         cfg = self.build_config(defn)
         orig_cfg = copy.deepcopy(cfg)
@@ -150,19 +178,25 @@ class Route53HealthCheckState(nixops.resources.ResourceState):
         if check or self.health_check_config != cfg:
             if not self.health_check_id:
                 ref = str(uuid.uuid1())
-                self.log('creating health check')
-                health_check = client.create_health_check(CallerReference=ref, HealthCheckConfig=cfg)
+                self.log("creating health check")
+                health_check = client.create_health_check(
+                    CallerReference=ref, HealthCheckConfig=cfg
+                )
                 with self.depl._db:
                     self.state = self.UP
-                    self.health_check_id = health_check['HealthCheck']['Id']
+                    self.health_check_id = health_check["HealthCheck"]["Id"]
             else:
-                health_check = client.get_health_check(HealthCheckId=self.health_check_id)
-                version = health_check['HealthCheck']['HealthCheckVersion']
-                cfg['HealthCheckId'] = self.health_check_id
-                cfg['HealthCheckVersion'] = version
-                if 'Type' in cfg: cfg.pop('Type')
-                if 'RequestInterval' in cfg: cfg.pop('RequestInterval')
-                self.log('updating health check')
+                health_check = client.get_health_check(
+                    HealthCheckId=self.health_check_id
+                )
+                version = health_check["HealthCheck"]["HealthCheckVersion"]
+                cfg["HealthCheckId"] = self.health_check_id
+                cfg["HealthCheckVersion"] = version
+                if "Type" in cfg:
+                    cfg.pop("Type")
+                if "RequestInterval" in cfg:
+                    cfg.pop("RequestInterval")
+                self.log("updating health check")
                 client.update_health_check(**cfg)
 
             with self.depl._db:
@@ -174,13 +208,14 @@ class Route53HealthCheckState(nixops.resources.ResourceState):
     def destroy(self, wipe=False):
         client = self.boto_session().client("route53")
 
-        if not self.health_check_id: return True
+        if not self.health_check_id:
+            return True
 
-        self.log('destroying health check {}'.format(self.health_check_id))
+        self.log("destroying health check {}".format(self.health_check_id))
         try:
             client.delete_health_check(HealthCheckId=self.health_check_id)
         except botocore.exceptions.ClientError as e:
-            if e.response['Error']['Code'] == 'NoSuchHealthCheck':
+            if e.response["Error"]["Code"] == "NoSuchHealthCheck":
                 pass
             raise
 
@@ -190,6 +225,12 @@ class Route53HealthCheckState(nixops.resources.ResourceState):
 
     def create_after(self, resources, defn):
         hcs = defn.child_health_checks if defn else self.child_health_checks
-        return {r for r in resources if isinstance(r, nixops.backends.MachineState) or \
-                 (isinstance(r, Route53HealthCheckState) and 'res-{}'.format(r.name) in hcs)}
-
+        return {
+            r
+            for r in resources
+            if isinstance(r, nixops.backends.MachineState)
+            or (
+                isinstance(r, Route53HealthCheckState)
+                and "res-{}".format(r.name) in hcs
+            )
+        }

--- a/nixopsaws/resources/route53_hosted_zone.py
+++ b/nixopsaws/resources/route53_hosted_zone.py
@@ -12,7 +12,8 @@ import nixops.resources
 import nixopsaws.ec2_utils
 from pprint import pprint
 
-#boto3.set_stream_logger(name='botocore')
+# boto3.set_stream_logger(name='botocore')
+
 
 class Route53HostedZoneDefinition(nixops.resources.ResourceDefinition):
     """Definition of an Route53 Hosted Zone."""
@@ -29,22 +30,24 @@ class Route53HostedZoneDefinition(nixops.resources.ResourceDefinition):
         nixops.resources.ResourceDefinition.__init__(self, xml, config)
         self.access_key_id = config["accessKeyId"]
         self.comment = config["comment"]
-        self.private_zone =  config["privateZone"]
-        self.zone_name = config['name']
-        self.associated_vpcs = config['associatedVPCs']
-        map(lambda x: x.pop('_module'), self.associated_vpcs)
+        self.private_zone = config["privateZone"]
+        self.zone_name = config["name"]
+        self.associated_vpcs = config["associatedVPCs"]
+        map(lambda x: x.pop("_module"), self.associated_vpcs)
 
 
 class Route53HostedZoneState(nixops.resources.ResourceState):
     """State of a Route53 Hosted Zone."""
 
-    state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.ResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
     zone_id = nixops.util.attr_property("route53.zoneId", None)
     zone_name = nixops.util.attr_property("route53.zoneName", None)
     private_zone = nixops.util.attr_property("route53.privateZone", False)
-    comment = nixops.util.attr_property('route53.comment', None)
-    delegation_set = nixops.util.attr_property('route53.delegationSet', [], 'json')
+    comment = nixops.util.attr_property("route53.comment", None)
+    delegation_set = nixops.util.attr_property("route53.delegationSet", [], "json")
 
     @classmethod
     def get_type(cls):
@@ -59,22 +62,27 @@ class Route53HostedZoneState(nixops.resources.ResourceState):
         return self.zone_id
 
     def prefix_definition(self, attr):
-        return {('resources', 'route53HostedZones'): attr}
+        return {("resources", "route53HostedZones"): attr}
 
     def get_physical_spec(self):
-        return { 'delegationSet': self.delegation_set}
+        return {"delegationSet": self.delegation_set}
 
     def boto_session(self):
         if self._boto_session is None:
-            (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(self.access_key_id)
+            (
+                access_key_id,
+                secret_access_key,
+            ) = nixopsaws.ec2_utils.fetch_aws_secret_key(self.access_key_id)
             self._boto_session = boto3.session.Session(
-                                               aws_access_key_id=access_key_id,
-                                               aws_secret_access_key=secret_access_key)
+                aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key
+            )
         return self._boto_session
 
     def create(self, defn, check, allow_reboot, allow_recreate):
-        self.access_key_id = defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
-        if not (self.access_key_id or os.environ['AWS_ACCESS_KEY_ID']):
+        self.access_key_id = (
+            defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+        )
+        if not (self.access_key_id or os.environ["AWS_ACCESS_KEY_ID"]):
             raise Exception("please set ‘accessKeyId’ or $AWS_ACCESS_KEY_ID")
 
         client = self.boto_session().client("route53")
@@ -85,39 +93,51 @@ class Route53HostedZoneState(nixops.resources.ResourceState):
 
         if not hosted_zone:
             args = {}
-            args['Name'] = defn.zone_name
-            args['CallerReference'] = str(uuid.uuid4())
-            args['HostedZoneConfig'] = { 'PrivateZone': defn.private_zone }
+            args["Name"] = defn.zone_name
+            args["CallerReference"] = str(uuid.uuid4())
+            args["HostedZoneConfig"] = {"PrivateZone": defn.private_zone}
 
             if defn.private_zone:
                 first_assoc = defn.associated_vpcs[0]
-                args['VPC'] = { 'VPCRegion': first_assoc['region'], 'VPCId': first_assoc['vpcId'] }
+                args["VPC"] = {
+                    "VPCRegion": first_assoc["region"],
+                    "VPCId": first_assoc["vpcId"],
+                }
 
-            self.log('creating hosted zone for {}'.format(defn.zone_name))
+            self.log("creating hosted zone for {}".format(defn.zone_name))
 
             hosted_zone = client.create_hosted_zone(**args)
             with self.depl._db:
                 self.state = self.UP
-                self.zone_id = hosted_zone['HostedZone']['Id']
+                self.zone_id = hosted_zone["HostedZone"]["Id"]
                 self.private_zone = defn.private_zone
                 self.zone_name = defn.zone_name
                 self.comment = defn.comment
-                self.delegation_set = hosted_zone['DelegationSet']['NameServers']
+                self.delegation_set = hosted_zone["DelegationSet"]["NameServers"]
 
         if defn.comment != self.comment or check:
             client.update_hosted_zone_comment(Id=self.zone_id, Comment=defn.comment)
 
         # associate VPC's
         if self.private_zone:
-            current = [ { 'region': assoc['VPCRegion'], 'vpcId': assoc['VPCId']} for assoc in hosted_zone['VPCs']]
-            tbd = [ assoc for assoc in current if not assoc in defn.associated_vpcs ]
-            tba = [ assoc for assoc in defn.associated_vpcs if not assoc in current]
+            current = [
+                {"region": assoc["VPCRegion"], "vpcId": assoc["VPCId"]}
+                for assoc in hosted_zone["VPCs"]
+            ]
+            tbd = [assoc for assoc in current if not assoc in defn.associated_vpcs]
+            tba = [assoc for assoc in defn.associated_vpcs if not assoc in current]
 
             for assoc in tba:
-                client.associate_vpc_with_hosted_zone(HostedZoneId=self.zone_id, VPC={ 'VPCId': assoc['vpcId'], 'VPCRegion': assoc['region'] })
+                client.associate_vpc_with_hosted_zone(
+                    HostedZoneId=self.zone_id,
+                    VPC={"VPCId": assoc["vpcId"], "VPCRegion": assoc["region"]},
+                )
 
             for assoc in tbd:
-                client.disassociate_vpc_from_hosted_zone(HostedZoneId=self.zone_id, VPC={ 'VPCId': assoc['vpcId'], 'VPCRegion': assoc['region'] })
+                client.disassociate_vpc_from_hosted_zone(
+                    HostedZoneId=self.zone_id,
+                    VPC={"VPCId": assoc["vpcId"], "VPCRegion": assoc["region"]},
+                )
 
         with self.depl._db:
             self.associated_vpcs = defn.associated_vpcs
@@ -127,17 +147,17 @@ class Route53HostedZoneState(nixops.resources.ResourceState):
     def destroy(self, wipe=False):
         client = self.boto_session().client("route53")
 
-        if not self.zone_id: return True
+        if not self.zone_id:
+            return True
 
-        self.log('destroying hosted zone for {}'.format(self.zone_name))
+        self.log("destroying hosted zone for {}".format(self.zone_name))
         try:
             client.delete_hosted_zone(Id=self.zone_id)
         except botocore.exceptions.ClientError as e:
-            if e.response['Error']['Code'] == 'NoSuchHostedZone':
+            if e.response["Error"]["Code"] == "NoSuchHostedZone":
                 pass
             raise
 
         with self.depl._db:
             self.state = self.MISSING
         return True
-

--- a/nixopsaws/resources/route53_recordset.py
+++ b/nixopsaws/resources/route53_recordset.py
@@ -7,7 +7,9 @@ import boto3
 import nixops.util
 import nixops.resources
 import nixopsaws.ec2_utils
-#boto3.set_stream_logger(name='botocore')
+
+# boto3.set_stream_logger(name='botocore')
+
 
 class Route53RecordSetDefinition(nixops.resources.ResourceDefinition):
     """Definition of a Route53 RecordSet."""
@@ -44,7 +46,9 @@ class Route53RecordSetDefinition(nixops.resources.ResourceDefinition):
 class Route53RecordSetState(nixops.resources.ResourceState):
     """State of a Route53 Recordset."""
 
-    state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.ResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("route53.accessKeyId", None)
 
     zone_id = nixops.util.attr_property("route53.zoneId", None)
@@ -56,7 +60,7 @@ class Route53RecordSetState(nixops.resources.ResourceState):
     ttl = nixops.util.attr_property("route53.ttl", None, int)
     routing_policy = nixops.util.attr_property("route53.routingPolicy", None)
     record_type = nixops.util.attr_property("route53.recordType", None)
-    record_values = nixops.util.attr_property("route53.recordValues", None, 'json')
+    record_values = nixops.util.attr_property("route53.recordValues", None, "json")
     health_check_id = nixops.util.attr_property("route53.healthCheckId", None)
 
     @classmethod
@@ -67,7 +71,6 @@ class Route53RecordSetState(nixops.resources.ResourceState):
         nixops.resources.ResourceState.__init__(self, depl, name, id)
         self._boto_session = None
 
-
     @property
     def resource_id(self):
         return self.domain_name
@@ -77,23 +80,34 @@ class Route53RecordSetState(nixops.resources.ResourceState):
 
     def boto_session(self):
         if self._boto_session is None:
-            (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(self.access_key_id)
+            (
+                access_key_id,
+                secret_access_key,
+            ) = nixopsaws.ec2_utils.fetch_aws_secret_key(self.access_key_id)
             self._boto_session = boto3.session.Session(
-                                               aws_access_key_id=access_key_id,
-                                               aws_secret_access_key=secret_access_key)
+                aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key
+            )
         return self._boto_session
 
     def create(self, defn, check, allow_reboot, allow_recreate):
-        self.access_key_id = defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
-        if not (self.access_key_id or os.environ['AWS_ACCESS_KEY_ID']):
-             raise Exception("please set ‘accessKeyId’ or $AWS_ACCESS_KEY_ID")
+        self.access_key_id = (
+            defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+        )
+        if not (self.access_key_id or os.environ["AWS_ACCESS_KEY_ID"]):
+            raise Exception("please set ‘accessKeyId’ or $AWS_ACCESS_KEY_ID")
 
         # Sanity checks for configuration
         if defn.domain_name is None:
-            raise Exception("No domain name set for Route 53 RecordSet '{0}'".format(defn.name))
+            raise Exception(
+                "No domain name set for Route 53 RecordSet '{0}'".format(defn.name)
+            )
 
         if len(defn.domain_name) > 253:
-            raise Exception("domain name ‘{0}’ is longer than 253 characters.".format(defn.domain_name))
+            raise Exception(
+                "domain name ‘{0}’ is longer than 253 characters.".format(
+                    defn.domain_name
+                )
+            )
 
         client = self.boto_session().client("route53")
 
@@ -104,76 +118,131 @@ class Route53RecordSetState(nixops.resources.ResourceState):
         if defn.zone_name is None:
             # Now zoneId should be defined.
             if defn.zone_id is None:
-                raise Exception("Neither zoneName nor zoneId is set for Route 53 Recordset '{0}'".format(defn.domain_name))
+                raise Exception(
+                    "Neither zoneName nor zoneId is set for Route 53 Recordset '{0}'".format(
+                        defn.domain_name
+                    )
+                )
             else:
                 if zone_id.startswith("res-"):
-                    hs = self.depl.get_typed_resource(zone_id[4:], "aws-route53-hosted-zone")
+                    hs = self.depl.get_typed_resource(
+                        zone_id[4:], "aws-route53-hosted-zone"
+                    )
                     if not hs.zone_id:
-                        raise Exception("cannot create record set in not-yet created hosted zone: ‘{0}’". format(defn.domain_name))
+                        raise Exception(
+                            "cannot create record set in not-yet created hosted zone: ‘{0}’".format(
+                                defn.domain_name
+                            )
+                        )
                     zone_id = hs.zone_id
 
                 # We have a zoneId, look up the zoneName
-                hosted_zone = self.route53_retry(lambda: client.get_hosted_zone(Id = zone_id))
+                hosted_zone = self.route53_retry(
+                    lambda: client.get_hosted_zone(Id=zone_id)
+                )
                 zone_name = hosted_zone["HostedZone"]["Name"][:-1]
         else:
             if defn.zone_id is not None:
-                raise Exception("Both zoneName and zoneId are set for Route 53 Recordset '{0}'".format(defn.domain_name))
+                raise Exception(
+                    "Both zoneName and zoneId are set for Route 53 Recordset '{0}'".format(
+                        defn.domain_name
+                    )
+                )
             else:
                 # We have the zoneName, find the zoneId
-                response = self.route53_retry(lambda: client.list_hosted_zones_by_name(DNSName=defn.zone_name))
-                zone_name = defn.zone_name if defn.zone_name.endswith('.') else (defn.zone_name + '.')
-                zones = filter((lambda zone: zone["Name"] == zone_name), response["HostedZones"])
+                response = self.route53_retry(
+                    lambda: client.list_hosted_zones_by_name(DNSName=defn.zone_name)
+                )
+                zone_name = (
+                    defn.zone_name
+                    if defn.zone_name.endswith(".")
+                    else (defn.zone_name + ".")
+                )
+                zones = filter(
+                    (lambda zone: zone["Name"] == zone_name), response["HostedZones"]
+                )
                 if len(zones) == 0:
                     raise Exception("Can't find zone id")
                 elif len(zones) > 1:
-                    raise Exception("Found more than one hosted zone for {}, please remove one, or define the zone ID explicitly.".format(defn.zone_name))
+                    raise Exception(
+                        "Found more than one hosted zone for {}, please remove one, or define the zone ID explicitly.".format(
+                            defn.zone_name
+                        )
+                    )
                 else:
                     zone_id = zones[0]["Id"]
 
         if self.routing_policy and self.routing_policy != defn.routing_policy:
-            raise Exception("Cannot change record routing policy from '{}' to '{}'".format(self.routing_policy, defn.routing_policy))
+            raise Exception(
+                "Cannot change record routing policy from '{}' to '{}'".format(
+                    self.routing_policy, defn.routing_policy
+                )
+            )
         if self.domain_name and self.domain_name != defn.domain_name:
-            raise Exception("Cannot change record domain name from '{}' to '{}'".format(self.domain_name, defn.domain_name))
+            raise Exception(
+                "Cannot change record domain name from '{}' to '{}'".format(
+                    self.domain_name, defn.domain_name
+                )
+            )
         if self.record_type and self.record_type != defn.record_type:
-            raise Exception("Cannot change record type from '{}' to '{}'".format(self.record_type, defn.record_type))
+            raise Exception(
+                "Cannot change record type from '{}' to '{}'".format(
+                    self.record_type, defn.record_type
+                )
+            )
         if self.zone_id and self.zone_id != zone_id:
-            raise Exception("Cannot change zone id from '{}' to '{}'.".format(self.zone_id, zone_id))
+            raise Exception(
+                "Cannot change zone id from '{}' to '{}'.".format(self.zone_id, zone_id)
+            )
         if self.set_identifier and self.set_identifier != defn.set_identifier:
-            raise Exception("Cannot change set identifier for a record from '{}' to '{}'.".format(self.set_identifier, defn.set_identifier))
-        if not zone_name.endswith('.'):
-            zone_name += '.'
+            raise Exception(
+                "Cannot change set identifier for a record from '{}' to '{}'.".format(
+                    self.set_identifier, defn.set_identifier
+                )
+            )
+        if not zone_name.endswith("."):
+            zone_name += "."
         # zone name should be suffix of the dns name, if the zone name is set.
         if not defn.domain_name.endswith(zone_name):
-            raise Exception("The domain name '{0}' does not end in the zone name '{1}'. You have to specify the FQDN for the zone name.".format(defn.domain_name, self.zone_name))
+            raise Exception(
+                "The domain name '{0}' does not end in the zone name '{1}'. You have to specify the FQDN for the zone name.".format(
+                    defn.domain_name, self.zone_name
+                )
+            )
 
         def resolve_machine_ip(v):
-            if v.startswith('res-'):
+            if v.startswith("res-"):
                 m = self.depl.get_machine(v[4:])
                 if not m.public_ipv4:
-                    raise Exception("cannot create record set for a machine that has not yet been created")
+                    raise Exception(
+                        "cannot create record set for a machine that has not yet been created"
+                    )
                 return m.public_ipv4
             else:
                 return v
 
-        defn.record_values = map(resolve_machine_ip , defn.record_values)
+        defn.record_values = map(resolve_machine_ip, defn.record_values)
 
-        changed = self.record_values != defn.record_values \
-               or self.ttl != defn.ttl \
-               or self.weight != defn.weight \
-               or self.health_check_id != defn.health_check_id
+        changed = (
+            self.record_values != defn.record_values
+            or self.ttl != defn.ttl
+            or self.weight != defn.weight
+            or self.health_check_id != defn.health_check_id
+        )
 
         if not changed and not check:
             return
 
-        self.log('creating/updating record set ({})'.format(self.to_string(defn)))
+        self.log("creating/updating record set ({})".format(self.to_string(defn)))
 
         # Don't care about the state for now. We'll just upsert!
         # TODO: Copy properties_changed function used in GCE/Azure's
         # check output of operation. It now just barfs an exception if something doesn't work properly
-        change_result = self.route53_retry(lambda: client.change_resource_record_sets(
-            HostedZoneId=zone_id,
-            ChangeBatch=self.make_batch('UPSERT', defn)
-        ))
+        change_result = self.route53_retry(
+            lambda: client.change_resource_record_sets(
+                HostedZoneId=zone_id, ChangeBatch=self.make_batch("UPSERT", defn)
+            )
+        )
 
         with self.depl._db:
             self.state = self.UP
@@ -192,70 +261,89 @@ class Route53RecordSetState(nixops.resources.ResourceState):
 
     def make_batch(self, action, obj):
         batch = {
-            'Changes': [
+            "Changes": [
                 {
-                    'Action': action,
-                    'ResourceRecordSet': {
-                        'Name': obj.domain_name,
-                        'Type': obj.record_type,
-                        'TTL': int(obj.ttl),
-                        'ResourceRecords': map(lambda rv: { 'Value': rv }, obj.record_values)
-                    }
+                    "Action": action,
+                    "ResourceRecordSet": {
+                        "Name": obj.domain_name,
+                        "Type": obj.record_type,
+                        "TTL": int(obj.ttl),
+                        "ResourceRecords": map(
+                            lambda rv: {"Value": rv}, obj.record_values
+                        ),
+                    },
                 },
             ]
         }
 
-        rs_batch = batch['Changes'][0]['ResourceRecordSet']
+        rs_batch = batch["Changes"][0]["ResourceRecordSet"]
 
         if obj.set_identifier and obj.set_identifier != "":
-            rs_batch.update({ 'SetIdentifier': obj.set_identifier })
+            rs_batch.update({"SetIdentifier": obj.set_identifier})
 
         if obj.routing_policy == "multivalue":
-            rs_batch.update({ 'MultiValueAnswer': True })
+            rs_batch.update({"MultiValueAnswer": True})
 
         if obj.routing_policy == "weighted":
-            rs_batch.update({ 'Weight': int(obj.weight) })
-
+            rs_batch.update({"Weight": int(obj.weight)})
 
         def resolve_health_check(v):
-            if v.startswith('res-'):
+            if v.startswith("res-"):
                 hc = self.depl.get_typed_resource(v[4:], "aws-route53-health-check")
                 if not hc.health_check_id:
-                    raise Exception("cannot refer to a health check resource that has not yet been created")
+                    raise Exception(
+                        "cannot refer to a health check resource that has not yet been created"
+                    )
                 return hc.health_check_id
             else:
                 return v
 
         if obj.health_check_id and obj.health_check_id != "":
-            rs_batch.update({ 'HealthCheckId': resolve_health_check(obj.health_check_id) })
+            rs_batch.update(
+                {"HealthCheckId": resolve_health_check(obj.health_check_id)}
+            )
 
         return batch
 
     def to_string(self, obj):
         res = "{}/{}".format(obj.record_type, obj.domain_name)
         if obj.set_identifier:
-             res += "/{}".format(obj.set_identifier)
+            res += "/{}".format(obj.set_identifier)
         return res
 
     def destroy(self, wipe=False):
-        if self.state == self.UP and self.depl.logger.confirm("are you sure you want to destroy record: {}".format(self.to_string(self))):
-            self.log('destroying record set ({})'.format(self.to_string(self)))
+        if self.state == self.UP and self.depl.logger.confirm(
+            "are you sure you want to destroy record: {}".format(self.to_string(self))
+        ):
+            self.log("destroying record set ({})".format(self.to_string(self)))
             client = self.boto_session().client("route53")
 
             # TODO: catch exception
-            change_result = self.route53_retry(lambda: client.change_resource_record_sets(
-                HostedZoneId=self.zone_id,
-                ChangeBatch=self.make_batch('DELETE', self)))
+            change_result = self.route53_retry(
+                lambda: client.change_resource_record_sets(
+                    HostedZoneId=self.zone_id,
+                    ChangeBatch=self.make_batch("DELETE", self),
+                )
+            )
 
             with self.depl._db:
                 self.state = self.MISSING
             return True
 
     def route53_retry(self, f):
-        return nixopsaws.ec2_utils.retry(f, error_codes=[ 'Throttling', 'PriorRequestNotComplete' ], logger=self)
+        return nixopsaws.ec2_utils.retry(
+            f, error_codes=["Throttling", "PriorRequestNotComplete"], logger=self
+        )
 
     def create_after(self, resources, defn):
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.route53_hosted_zone.Route53HostedZoneState) or
-                isinstance(r, nixopsaws.resources.route53_health_check.Route53HealthCheckState) or
-                isinstance(r, nixops.backends.MachineState)}
+        return {
+            r
+            for r in resources
+            if isinstance(
+                r, nixopsaws.resources.route53_hosted_zone.Route53HostedZoneState
+            )
+            or isinstance(
+                r, nixopsaws.resources.route53_health_check.Route53HealthCheckState
+            )
+            or isinstance(r, nixops.backends.MachineState)
+        }

--- a/nixopsaws/resources/s3_bucket.py
+++ b/nixopsaws/resources/s3_bucket.py
@@ -26,7 +26,9 @@ class S3BucketDefinition(nixops.resources.ResourceDefinition):
         nixops.resources.ResourceDefinition.__init__(self, xml, config)
         self.bucket_name = xml.find("attrs/attr[@name='name']/string").get("value")
         self.region = xml.find("attrs/attr[@name='region']/string").get("value")
-        self.access_key_id = xml.find("attrs/attr[@name='accessKeyId']/string").get("value")
+        self.access_key_id = xml.find("attrs/attr[@name='accessKeyId']/string").get(
+            "value"
+        )
         self.policy = xml.find("attrs/attr[@name='policy']/string").get("value")
         self.lifecycle = xml.find("attrs/attr[@name='lifeCycle']/string").get("value")
         self.versioning = xml.find("attrs/attr[@name='versioning']/string").get("value")
@@ -42,29 +44,28 @@ class S3BucketDefinition(nixops.resources.ResourceDefinition):
 class S3BucketState(nixops.resources.ResourceState):
     """State of an S3 bucket."""
 
-    state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.ResourceState.MISSING, int
+    )
     bucket_name = nixops.util.attr_property("ec2.bucketName", None)
     access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
     region = nixops.util.attr_property("ec2.region", None)
     versioning = nixops.util.attr_property("versioning", None)
     persist_on_destroy = nixops.util.attr_property("persistOnDestroy", False)
 
-
     @classmethod
     def get_type(cls):
         return "s3-bucket"
-
 
     def __init__(self, depl, name, id):
         nixops.resources.ResourceState.__init__(self, depl, name, id)
         self._conn = None
 
-
     def show_type(self):
         s = super(S3BucketState, self).show_type()
-        if self.region: s = "{0} [{1}]".format(s, self.region)
+        if self.region:
+            s = "{0} [{1}]".format(s, self.region)
         return s
-
 
     @property
     def resource_id(self):
@@ -74,40 +75,53 @@ class S3BucketState(nixops.resources.ResourceState):
         return "resources.s3Buckets."
 
     def connect(self):
-        if self._conn: return
-        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(self.access_key_id)
-        self._conn = boto3.session.Session(region_name=self.region if self.region != "US" else "us-east-1",
-                                           aws_access_key_id=access_key_id,
-                                           aws_secret_access_key=secret_access_key)
+        if self._conn:
+            return
+        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(
+            self.access_key_id
+        )
+        self._conn = boto3.session.Session(
+            region_name=self.region if self.region != "US" else "us-east-1",
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+        )
 
     def create(self, defn, check, allow_reboot, allow_recreate):
 
-        self.access_key_id = defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+        self.access_key_id = (
+            defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+        )
         if not self.access_key_id:
-            raise Exception("please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID")
+            raise Exception(
+                "please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID"
+            )
 
         if len(defn.bucket_name) > 63:
-            raise Exception("bucket name ‘{0}’ is longer than 63 characters.".format(defn.bucket_name))
+            raise Exception(
+                "bucket name ‘{0}’ is longer than 63 characters.".format(
+                    defn.bucket_name
+                )
+            )
 
         self.connect()
-        s3client = self._conn.client('s3')
+        s3client = self._conn.client("s3")
         if check or self.state != self.UP:
 
             self.log("creating S3 bucket ‘{0}’...".format(defn.bucket_name))
             try:
-                ACL = 'private' # ..or: public-read, public-read-write, authenticated-read
+                ACL = "private"  # ..or: public-read, public-read-write, authenticated-read
                 s3loc = region_to_s3_location(defn.region)
                 if s3loc == "US":
-                    s3client.create_bucket(ACL = ACL,
-                                           Bucket = defn.bucket_name)
+                    s3client.create_bucket(ACL=ACL, Bucket=defn.bucket_name)
                 else:
-                    s3client.create_bucket(ACL = ACL,
-                                           Bucket = defn.bucket_name,
-                                           CreateBucketConfiguration = {
-                                               'LocationConstraint': s3loc
-                                           })
+                    s3client.create_bucket(
+                        ACL=ACL,
+                        Bucket=defn.bucket_name,
+                        CreateBucketConfiguration={"LocationConstraint": s3loc},
+                    )
             except botocore.exceptions.ClientError as e:
-                if e.response['Error']['Code'] != "BucketAlreadyOwnedByYou": raise
+                if e.response["Error"]["Code"] != "BucketAlreadyOwnedByYou":
+                    raise
 
             with self.depl._db:
                 self.state = self.UP
@@ -118,9 +132,15 @@ class S3BucketState(nixops.resources.ResourceState):
         try:
 
             if self.versioning != defn.versioning:
-                self.log("Updating versioning configuration on ‘{0}’...".format(defn.bucket_name))
-                s3client.put_bucket_versioning(Bucket = defn.bucket_name,
-                                                VersioningConfiguration = {'Status': defn.versioning})
+                self.log(
+                    "Updating versioning configuration on ‘{0}’...".format(
+                        defn.bucket_name
+                    )
+                )
+                s3client.put_bucket_versioning(
+                    Bucket=defn.bucket_name,
+                    VersioningConfiguration={"Status": defn.versioning},
+                )
                 with self.depl._db:
                     self.versioning = defn.versioning
 
@@ -129,71 +149,100 @@ class S3BucketState(nixops.resources.ResourceState):
                     self.persist_on_destroy = defn.persist_on_destroy
 
         except botocore.exceptions.ClientError as e:
-            self.log("An Error occured while Updating versioning configuration on ‘{0}’...".format(defn.bucket_name))
+            self.log(
+                "An Error occured while Updating versioning configuration on ‘{0}’...".format(
+                    defn.bucket_name
+                )
+            )
             raise e
 
         if defn.policy:
             self.log("setting S3 bucket policy on ‘{0}’...".format(defn.bucket_name))
-            s3client.put_bucket_policy(Bucket = defn.bucket_name,
-                                       Policy = defn.policy.strip())
+            s3client.put_bucket_policy(
+                Bucket=defn.bucket_name, Policy=defn.policy.strip()
+            )
         else:
             try:
-                s3client.delete_bucket_policy(Bucket = defn.bucket_name)
+                s3client.delete_bucket_policy(Bucket=defn.bucket_name)
             except botocore.exceptions.ClientError as e:
                 # This seems not to happen - despite docs indicating it should:
                 # [http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketDELETEpolicy.html]
-                if e.response['ResponseMetadata']['HTTPStatusCode'] != 204: raise # (204 : Bucket didn't have any policy to delete)
+                if e.response["ResponseMetadata"]["HTTPStatusCode"] != 204:
+                    raise  # (204 : Bucket didn't have any policy to delete)
 
         if defn.lifecycle:
-            self.log("setting S3 bucket lifecycle configuration on ‘{0}’...".format(defn.bucket_name))
-            s3client.put_bucket_lifecycle_configuration(Bucket = defn.bucket_name,
-                                       LifecycleConfiguration = json.loads(defn.lifecycle))
+            self.log(
+                "setting S3 bucket lifecycle configuration on ‘{0}’...".format(
+                    defn.bucket_name
+                )
+            )
+            s3client.put_bucket_lifecycle_configuration(
+                Bucket=defn.bucket_name,
+                LifecycleConfiguration=json.loads(defn.lifecycle),
+            )
         else:
             try:
-                s3client.delete_bucket_lifecycle(Bucket = defn.bucket_name)
+                s3client.delete_bucket_lifecycle(Bucket=defn.bucket_name)
             except botocore.exceptions.ClientError as e:
-                self.log("An Error occured while deleting lifecycle configuration on ‘{0}’...".format(defn.bucket_name))
+                self.log(
+                    "An Error occured while deleting lifecycle configuration on ‘{0}’...".format(
+                        defn.bucket_name
+                    )
+                )
                 raise e
 
         if not defn.website_enabled:
             try:
-                s3client.delete_bucket_website(Bucket = defn.bucket_name)
+                s3client.delete_bucket_website(Bucket=defn.bucket_name)
             except botocore.exceptions.ClientError as e:
-                if e.response['ResponseMetadata']['HTTPStatusCode'] != 204: raise
+                if e.response["ResponseMetadata"]["HTTPStatusCode"] != 204:
+                    raise
         else:
-            website_config = { 'IndexDocument': { 'Suffix': defn.website_suffix } }
+            website_config = {"IndexDocument": {"Suffix": defn.website_suffix}}
             if defn.website_error_document != "":
-                website_config['ErrorDocument'] = { 'Key': defn.website_error_document}
-            s3client.put_bucket_website(Bucket = defn.bucket_name, WebsiteConfiguration = website_config)
-
-
+                website_config["ErrorDocument"] = {"Key": defn.website_error_document}
+            s3client.put_bucket_website(
+                Bucket=defn.bucket_name, WebsiteConfiguration=website_config
+            )
 
     def destroy(self, wipe=False):
         if self.state == self.UP:
             if self.persist_on_destroy:
-                self.warn("S3 bucket '{}' will be left due to the usage of"
-                          " persistOnDestroy = true".format(self.bucket_name))
-                return True;
+                self.warn(
+                    "S3 bucket '{}' will be left due to the usage of"
+                    " persistOnDestroy = true".format(self.bucket_name)
+                )
+                return True
 
             self.connect()
             try:
                 self.log("destroying S3 bucket ‘{0}’...".format(self.bucket_name))
-                bucket = self._conn.resource('s3').Bucket(self.bucket_name)
+                bucket = self._conn.resource("s3").Bucket(self.bucket_name)
                 try:
                     bucket.delete()
                 except botocore.exceptions.ClientError as e:
-                    if e.response['Error']['Code'] != "BucketNotEmpty": raise
-                    if not self.depl.logger.confirm("are you sure you want to destroy S3 bucket ‘{0}’?".format(self.bucket_name)): return False
+                    if e.response["Error"]["Code"] != "BucketNotEmpty":
+                        raise
+                    if not self.depl.logger.confirm(
+                        "are you sure you want to destroy S3 bucket ‘{0}’?".format(
+                            self.bucket_name
+                        )
+                    ):
+                        return False
                     bucket.objects.all().delete()
                     bucket.delete()
             except botocore.exceptions.ClientError as e:
-                if e.response['Error']['Code'] != "NoSuchBucket": raise
+                if e.response["Error"]["Code"] != "NoSuchBucket":
+                    raise
         return True
 
 
 def region_to_s3_location(region):
     # S3 location names are identical to EC2 regions, except for
     # us-east-1 and eu-west-1.
-    if region == "eu-west-1": return "EU"
-    elif region == "us-east-1": return "US"
-    else: return region
+    if region == "eu-west-1":
+        return "EU"
+    elif region == "us-east-1":
+        return "US"
+    else:
+        return region

--- a/nixopsaws/resources/sns_topic.py
+++ b/nixopsaws/resources/sns_topic.py
@@ -9,6 +9,7 @@ import nixops.resources
 import nixopsaws.ec2_utils
 from xml.etree import ElementTree
 
+
 class SNSTopicDefinition(nixops.resources.ResourceDefinition):
     """Definition of an SNS topic."""
 
@@ -27,14 +28,16 @@ class SNSTopicDefinition(nixops.resources.ResourceDefinition):
 class SNSTopicState(nixops.resources.ResourceState):
     """State of an SNS topic."""
 
-    state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.ResourceState.MISSING, int
+    )
     topic_name = nixops.util.attr_property("ec2.topicName", None)
     access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
     display_name = nixops.util.attr_property("ec2.topicDisplayName", None)
     region = nixops.util.attr_property("ec2.region", None)
     policy = nixops.util.attr_property("ec2.topicPolicy", None)
     arn = nixops.util.attr_property("ec2.topicARN", None)
-    subscriptions = nixops.util.attr_property("ec2.topicSubscriptions", [],'json')
+    subscriptions = nixops.util.attr_property("ec2.topicSubscriptions", [], "json")
 
     @classmethod
     def get_type(cls):
@@ -46,7 +49,8 @@ class SNSTopicState(nixops.resources.ResourceState):
 
     def show_type(self):
         s = super(SNSTopicState, self).show_type()
-        if self.region: s = "{0} [{1}]".format(s, self.region)
+        if self.region:
+            s = "{0} [{1}]".format(s, self.region)
         return s
 
     @property
@@ -54,23 +58,30 @@ class SNSTopicState(nixops.resources.ResourceState):
         return self.topic_name
 
     def prefix_definition(self, attr):
-        return {('resources', 'snsTopics'): attr}
+        return {("resources", "snsTopics"): attr}
 
     def get_physical_spec(self):
-        return {'arn': self.arn}
+        return {"arn": self.arn}
 
     def get_definition_prefix(self):
         return "resources.snsTopics."
 
     def connect(self):
-        if self._conn: return
+        if self._conn:
+            return
         assert self.region
-        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(self.access_key_id)
+        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(
+            self.access_key_id
+        )
         self._conn = boto.sns.connect_to_region(
-            region_name=self.region, aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
+            region_name=self.region,
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+        )
 
     def _destroy(self):
-        if self.state != self.UP: return
+        if self.state != self.UP:
+            return
         self.connect()
         self.log("destroying SNS topic ‘{0}’...".format(self.topic_name))
         self._conn.delete_topic(self.arn)
@@ -81,85 +92,115 @@ class SNSTopicState(nixops.resources.ResourceState):
             self.policy = None
             self.arn = None
 
-    def topic_exists(self,arn):
+    def topic_exists(self, arn):
         response = self._conn.get_all_topics()
-        topics = response['ListTopicsResponse']['ListTopicsResult']['Topics']
+        topics = response["ListTopicsResponse"]["ListTopicsResult"]["Topics"]
         current_topics = []
         if len(topics) > 0:
             for topic in topics:
-                topic_arn = topic['TopicArn']
+                topic_arn = topic["TopicArn"]
                 current_topics.append(topic_arn)
             if arn in current_topics:
                 return True
         return False
 
     def create(self, defn, check, allow_reboot, allow_recreate):
-        self.access_key_id = defn.config['accessKeyId'] or nixopsaws.ec2_utils.get_access_key_id()
+        self.access_key_id = (
+            defn.config["accessKeyId"] or nixopsaws.ec2_utils.get_access_key_id()
+        )
         if not self.access_key_id:
-            raise Exception("please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID")
+            raise Exception(
+                "please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID"
+            )
 
         arn = self.arn
-        if self.state == self.UP and (self.topic_name != defn.config['name'] or self.region != defn.config['region']):
+        if self.state == self.UP and (
+            self.topic_name != defn.config["name"]
+            or self.region != defn.config["region"]
+        ):
             self.log("topic definition changed, recreating...")
             self._destroy()
             self._conn = None
 
-        self.region = defn.config['region']
+        self.region = defn.config["region"]
         self.connect()
 
         if self.arn == None or not self.topic_exists(arn=self.arn):
-            self.log("creating SNS topic ‘{0}’...".format(defn.config['name']))
-            topic = self._conn.create_topic(defn.config['name'])
-            arn = topic.get('CreateTopicResponse').get('CreateTopicResult')['TopicArn']
+            self.log("creating SNS topic ‘{0}’...".format(defn.config["name"]))
+            topic = self._conn.create_topic(defn.config["name"])
+            arn = topic.get("CreateTopicResponse").get("CreateTopicResult")["TopicArn"]
 
-        if defn.config['displayName'] != None:
-            self._conn.set_topic_attributes(topic=arn,attr_name="DisplayName",attr_value=defn.config['displayName'])
+        if defn.config["displayName"] != None:
+            self._conn.set_topic_attributes(
+                topic=arn,
+                attr_name="DisplayName",
+                attr_value=defn.config["displayName"],
+            )
 
-        if defn.config['policy'] != "":
-            policy = self._conn.set_topic_attributes(topic=arn,attr_name="Policy",attr_value=defn.config['policy'])
+        if defn.config["policy"] != "":
+            policy = self._conn.set_topic_attributes(
+                topic=arn, attr_name="Policy", attr_value=defn.config["policy"]
+            )
 
-        current_subscribers, current_subscriptions_arns = self.get_current_subscribers(arn=arn)
+        current_subscribers, current_subscriptions_arns = self.get_current_subscribers(
+            arn=arn
+        )
 
-        if len(defn.config['subscriptions']) > 0:
-            for subscriber in defn.config['subscriptions']:
-                protocol = subscriber['protocol']
-                endpoint = subscriber['endpoint']
+        if len(defn.config["subscriptions"]) > 0:
+            for subscriber in defn.config["subscriptions"]:
+                protocol = subscriber["protocol"]
+                endpoint = subscriber["endpoint"]
                 if endpoint not in current_subscribers:
-                    self.log("adding SNS subscriber with endpoint '{0}'...".format(endpoint))
-                    self._conn.subscribe(topic=arn,protocol=protocol,endpoint=endpoint)
+                    self.log(
+                        "adding SNS subscriber with endpoint '{0}'...".format(endpoint)
+                    )
+                    self._conn.subscribe(
+                        topic=arn, protocol=protocol, endpoint=endpoint
+                    )
 
         defn_endpoints = self.get_defn_endpoints(defn)
         if len(defn_endpoints) > 0:
-            for subscriber_endpoint, subscriber_arn in current_subscriptions_arns.items():
+            for (
+                subscriber_endpoint,
+                subscriber_arn,
+            ) in current_subscriptions_arns.items():
                 if subscriber_endpoint not in defn_endpoints:
-                    self.log("removing SNS subscriber with endpoint '{0}'...".format(subscriber_endpoint))
-                    if subscriber_arn != "PendingConfirmation": 
-                     self._conn.unsubscribe(subscription=subscriber_arn)
+                    self.log(
+                        "removing SNS subscriber with endpoint '{0}'...".format(
+                            subscriber_endpoint
+                        )
+                    )
+                    if subscriber_arn != "PendingConfirmation":
+                        self._conn.unsubscribe(subscription=subscriber_arn)
 
         with self.depl._db:
             self.state = self.UP
-            self.topic_name = defn.config['name']
-            self.display_name = defn.config['displayName']
-            self.policy = defn.config['policy']
+            self.topic_name = defn.config["name"]
+            self.display_name = defn.config["displayName"]
+            self.policy = defn.config["policy"]
             self.arn = arn
-            self.subscriptions = defn.config['subscriptions']
+            self.subscriptions = defn.config["subscriptions"]
 
-    def get_current_subscribers(self,arn):
+    def get_current_subscribers(self, arn):
         response = self._conn.get_all_subscriptions_by_topic(topic=arn)
-        current_subscribers = response['ListSubscriptionsByTopicResponse']['ListSubscriptionsByTopicResult']['Subscriptions']
+        current_subscribers = response["ListSubscriptionsByTopicResponse"][
+            "ListSubscriptionsByTopicResult"
+        ]["Subscriptions"]
         current_endpoints = []
         current_subscriptions_arns = {}
         if len(current_subscribers) > 0:
-         for subscriber in current_subscribers:
-             current_endpoints.append(subscriber['Endpoint'])
-             current_subscriptions_arns[subscriber['Endpoint']]=subscriber['SubscriptionArn']
-        return current_endpoints,current_subscriptions_arns
+            for subscriber in current_subscribers:
+                current_endpoints.append(subscriber["Endpoint"])
+                current_subscriptions_arns[subscriber["Endpoint"]] = subscriber[
+                    "SubscriptionArn"
+                ]
+        return current_endpoints, current_subscriptions_arns
 
-    def get_defn_endpoints(self,defn):
+    def get_defn_endpoints(self, defn):
         defn_endpoints = []
-        if len(defn.config['subscriptions']) > 0:
-            for subscriber in defn.config['subscriptions']:
-                defn_endpoints.append(subscriber['endpoint'])
+        if len(defn.config["subscriptions"]) > 0:
+            for subscriber in defn.config["subscriptions"]:
+                defn_endpoints.append(subscriber["endpoint"])
         return defn_endpoints
 
     def destroy(self, wipe=False):

--- a/nixopsaws/resources/sqs_queue.py
+++ b/nixopsaws/resources/sqs_queue.py
@@ -24,8 +24,12 @@ class SQSQueueDefinition(nixops.resources.ResourceDefinition):
         nixops.resources.ResourceDefinition.__init__(self, xml)
         self.queue_name = xml.find("attrs/attr[@name='name']/string").get("value")
         self.region = xml.find("attrs/attr[@name='region']/string").get("value")
-        self.access_key_id = xml.find("attrs/attr[@name='accessKeyId']/string").get("value")
-        self.visibility_timeout = xml.find("attrs/attr[@name='visibilityTimeout']/int").get("value")
+        self.access_key_id = xml.find("attrs/attr[@name='accessKeyId']/string").get(
+            "value"
+        )
+        self.visibility_timeout = xml.find(
+            "attrs/attr[@name='visibilityTimeout']/int"
+        ).get("value")
 
     def show_type(self):
         return "{0} [{1}]".format(self.get_type(), self.region)
@@ -34,7 +38,9 @@ class SQSQueueDefinition(nixops.resources.ResourceDefinition):
 class SQSQueueState(nixops.resources.ResourceState):
     """State of an SQS queue."""
 
-    state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.ResourceState.MISSING, int
+    )
     queue_name = nixops.util.attr_property("ec2.queueName", None)
     access_key_id = nixops.util.attr_property("ec2.accessKeyId", None)
     region = nixops.util.attr_property("ec2.region", None)
@@ -46,39 +52,42 @@ class SQSQueueState(nixops.resources.ResourceState):
     def get_type(cls):
         return "sqs-queue"
 
-
     def __init__(self, depl, name, id):
         nixops.resources.ResourceState.__init__(self, depl, name, id)
         self._conn = None
 
-
     def show_type(self):
         s = super(SQSQueueState, self).show_type()
-        if self.region: s = "{0} [{1}]".format(s, self.region)
+        if self.region:
+            s = "{0} [{1}]".format(s, self.region)
         return s
 
     def prefix_definition(self, attr):
-        return {('resources', 'sqsQueues'): attr}
+        return {("resources", "sqsQueues"): attr}
 
     def get_physical_spec(self):
-        return {'url': self.url,
-                'arn': self.arn}
+        return {"url": self.url, "arn": self.arn}
 
     @property
     def resource_id(self):
         return self.queue_name
 
-
     def connect(self):
-        if self._conn: return
+        if self._conn:
+            return
         assert self.region
-        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(self.access_key_id)
+        (access_key_id, secret_access_key) = nixopsaws.ec2_utils.fetch_aws_secret_key(
+            self.access_key_id
+        )
         self._conn = boto.sqs.connect_to_region(
-            region_name=self.region, aws_access_key_id=access_key_id, aws_secret_access_key=secret_access_key)
-
+            region_name=self.region,
+            aws_access_key_id=access_key_id,
+            aws_secret_access_key=secret_access_key,
+        )
 
     def _destroy(self):
-        if self.state != self.UP: return
+        if self.state != self.UP:
+            return
         self.connect()
         q = self._conn.lookup(self.queue_name)
         if q:
@@ -93,17 +102,22 @@ class SQSQueueState(nixops.resources.ResourceState):
             self.region = None
             self.access_key_id = None
 
-
     def create(self, defn, check, allow_reboot, allow_recreate):
 
-        self.access_key_id = defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+        self.access_key_id = (
+            defn.access_key_id or nixopsaws.ec2_utils.get_access_key_id()
+        )
         if not self.access_key_id:
-            raise Exception("please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID")
+            raise Exception(
+                "please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID"
+            )
 
-        if self.state == self.UP and (self.queue_name != defn.queue_name or self.region != defn.region):
+        if self.state == self.UP and (
+            self.queue_name != defn.queue_name or self.region != defn.region
+        ):
             self.log("queue definition changed, recreating...")
             self._destroy()
-            self._conn = None # necessary if region changed
+            self._conn = None  # necessary if region changed
 
         if check or self.state != self.UP:
 
@@ -116,17 +130,26 @@ class SQSQueueState(nixops.resources.ResourceState):
                 if q:
                     # SQS requires us to wait for 60 seconds to
                     # recreate a queue.
-                    self.log("deleting queue ‘{0}’ (and waiting 60 seconds)...".format(defn.queue_name))
+                    self.log(
+                        "deleting queue ‘{0}’ (and waiting 60 seconds)...".format(
+                            defn.queue_name
+                        )
+                    )
                     self._conn.delete_queue(q)
                     time.sleep(61)
                 self.log("creating SQS queue ‘{0}’...".format(defn.queue_name))
-                q = nixopsaws.ec2_utils.retry(lambda: self._conn.create_queue(defn.queue_name, defn.visibility_timeout), error_codes = ['AWS.SimpleQueueService.QueueDeletedRecently'])
+                q = nixopsaws.ec2_utils.retry(
+                    lambda: self._conn.create_queue(
+                        defn.queue_name, defn.visibility_timeout
+                    ),
+                    error_codes=["AWS.SimpleQueueService.QueueDeletedRecently"],
+                )
 
             with self.depl._db:
                 self.state = self.UP
                 self.queue_name = defn.queue_name
                 self.url = q.url
-                self.arn = q.get_attributes()['QueueArn']
+                self.arn = q.get_attributes()["QueueArn"]
 
     def destroy(self, wipe=False):
         self._destroy()

--- a/nixopsaws/resources/vpc.py
+++ b/nixopsaws/resources/vpc.py
@@ -12,6 +12,7 @@ import nixopsaws.ec2_utils
 from nixops.state import StateDict
 from nixops.diff import Diff, Handler
 
+
 class VPCDefinition(nixops.resources.ResourceDefinition):
     """Definition of a VPC."""
 
@@ -30,7 +31,9 @@ class VPCDefinition(nixops.resources.ResourceDefinition):
 class VPCState(nixops.resources.DiffEngineResourceState, EC2CommonState):
     """State of a VPC."""
 
-    state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.ResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("accessKeyId", None)
     _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ["vpcId", "associationId"]
 
@@ -40,45 +43,58 @@ class VPCState(nixops.resources.DiffEngineResourceState, EC2CommonState):
 
     def __init__(self, depl, name, id):
         nixops.resources.DiffEngineResourceState.__init__(self, depl, name, id)
-        self.vpc_id = self._state.get('vpcId', None)
-        self.handle_create = Handler(['cidrBlock', 'region', 'instanceTenancy'], handle=self.realize_create_vpc)
-        self.handle_dns = Handler(['enableDnsHostnames', 'enableDnsSupport'], after=[self.handle_create]
-                                  , handle=self.realize_dns_config)
-        self.handle_classic_link = Handler(['enableClassicLink'], after=[self.handle_create]
-                                           , handle=self.realize_classic_link_change)
-        self.handle_associate_ipv6_cidr_block = Handler(
-            ['amazonProvidedIpv6CidrBlock'],
+        self.vpc_id = self._state.get("vpcId", None)
+        self.handle_create = Handler(
+            ["cidrBlock", "region", "instanceTenancy"], handle=self.realize_create_vpc
+        )
+        self.handle_dns = Handler(
+            ["enableDnsHostnames", "enableDnsSupport"],
             after=[self.handle_create],
-            handle=self.realize_associate_ipv6_cidr_block)
-        self.handle_tag_update = Handler(['tags'], after=[self.handle_create], handle=self.realize_update_tag)
+            handle=self.realize_dns_config,
+        )
+        self.handle_classic_link = Handler(
+            ["enableClassicLink"],
+            after=[self.handle_create],
+            handle=self.realize_classic_link_change,
+        )
+        self.handle_associate_ipv6_cidr_block = Handler(
+            ["amazonProvidedIpv6CidrBlock"],
+            after=[self.handle_create],
+            handle=self.realize_associate_ipv6_cidr_block,
+        )
+        self.handle_tag_update = Handler(
+            ["tags"], after=[self.handle_create], handle=self.realize_update_tag
+        )
 
     def show_type(self):
         s = super(VPCState, self).show_type()
-        region = self._state.get('region', None)
-        if region: s = "{0} [{1}]".format(s, region)
+        region = self._state.get("region", None)
+        if region:
+            s = "{0} [{1}]".format(s, region)
         return s
 
     @property
     def resource_id(self):
-        return self._state.get('vpcId', None)
+        return self._state.get("vpcId", None)
 
     def prefix_definition(self, attr):
-        return {('resources', 'vpc'): attr}
+        return {("resources", "vpc"): attr}
 
     def get_physical_spec(self):
-        return { 'vpcId': self._state.get('vpcId', None)}
+        return {"vpcId": self._state.get("vpcId", None)}
 
     def get_definition_prefix(self):
         return "resources.vpc."
 
     def _destroy(self):
-        if self.state != self.UP: return
-        self.log("destroying vpc {0}...".format(self._state['vpcId']))
+        if self.state != self.UP:
+            return
+        self.log("destroying vpc {0}...".format(self._state["vpcId"]))
         try:
-            self.get_client().delete_vpc(VpcId=self._state['vpcId'])
+            self.get_client().delete_vpc(VpcId=self._state["vpcId"])
         except botocore.exceptions.ClientError as e:
-            if e.response['Error']['Code'] == 'InvalidVpcID.NotFound':
-                self.warn("vpc {0} was already deleted".format(self._state['vpcId']))
+            if e.response["Error"]["Code"] == "InvalidVpcID.NotFound":
+                self.warn("vpc {0} was already deleted".format(self._state["vpcId"]))
             else:
                 raise e
 
@@ -87,47 +103,59 @@ class VPCState(nixops.resources.DiffEngineResourceState, EC2CommonState):
     def cleanup_state(self):
         with self.depl._db:
             self.state = self.MISSING
-            self._state['vpcId'] = None
-            self._state['region'] = None
-            self._state['cidrBlock'] = None
-            self._state['instanceTenancy'] = None
-            self._state['enableDnsSupport'] = None
-            self._state['enableDnsHostname'] = None
-            self._state['enableVpcClassicLink'] = None
+            self._state["vpcId"] = None
+            self._state["region"] = None
+            self._state["cidrBlock"] = None
+            self._state["instanceTenancy"] = None
+            self._state["enableDnsSupport"] = None
+            self._state["enableDnsHostname"] = None
+            self._state["enableVpcClassicLink"] = None
 
     def _check(self):
-        if self._state.get('vpcId', None) is None:
+        if self._state.get("vpcId", None) is None:
             return
         try:
             self.get_client().describe_vpcs(VpcIds=[self._state["vpcId"]])
         except botocore.exceptions.ClientError as e:
-            if e.response['Error']['Code'] == 'InvalidVpcID.NotFound':
-                self.warn("vpc {0} was deleted from outside nixops,"
-                          " it needs to be recreated...".format(self._state["vpcId"]))
+            if e.response["Error"]["Code"] == "InvalidVpcID.NotFound":
+                self.warn(
+                    "vpc {0} was deleted from outside nixops,"
+                    " it needs to be recreated...".format(self._state["vpcId"])
+                )
                 self.cleanup_state()
                 return
         if self.state == self.STARTING:
-            self.wait_for_vpc_available(self._state['vpcId'])
+            self.wait_for_vpc_available(self._state["vpcId"])
 
     def create_after(self, resources, defn):
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.elastic_ip.ElasticIPState)}
+        return {
+            r
+            for r in resources
+            if isinstance(r, nixopsaws.resources.elastic_ip.ElasticIPState)
+        }
 
     def wait_for_vpc_available(self, vpc_id):
         while True:
             response = self.get_client().describe_vpcs(VpcIds=[vpc_id])
-            if len(response['Vpcs']) == 1:
-                vpc = response['Vpcs'][0]
-                if vpc['State'] == "available":
+            if len(response["Vpcs"]) == 1:
+                vpc = response["Vpcs"][0]
+                if vpc["State"] == "available":
                     break
-                elif vpc['State'] != "pending":
-                    raise Exception("vpc {0} is in an unexpected state {1}".format(
-                        vpc_id, vpc['State']))
+                elif vpc["State"] != "pending":
+                    raise Exception(
+                        "vpc {0} is in an unexpected state {1}".format(
+                            vpc_id, vpc["State"]
+                        )
+                    )
 
                 self.log_continue(".")
                 time.sleep(1)
             else:
-                raise Exception("couldn't find vpc {}, please run a deploy with --check".format(self._state["vpcId"]))
+                raise Exception(
+                    "couldn't find vpc {}, please run a deploy with --check".format(
+                        self._state["vpcId"]
+                    )
+                )
         self.log_end(" done")
 
         with self.depl._db:
@@ -138,28 +166,36 @@ class VPCState(nixops.resources.DiffEngineResourceState, EC2CommonState):
         config = self.get_defn()
         if self.state == self.UP:
             if not allow_recreate:
-                raise Exception("vpc {} definition changed and it needs to be recreated "
-                                "use --allow-recreate if you want to create a new one".format(self.vpc_id))
+                raise Exception(
+                    "vpc {} definition changed and it needs to be recreated "
+                    "use --allow-recreate if you want to create a new one".format(
+                        self.vpc_id
+                    )
+                )
             self.warn("vpc definition changed, recreating...")
             self._destroy()
             self._client = None
 
-        self._state["region"] = config['region']
+        self._state["region"] = config["region"]
 
-        self.log("creating vpc under region {0}".format(config['region']))
-        vpc = self.get_client().create_vpc(CidrBlock=config['cidrBlock'],
-                                      InstanceTenancy=config['instanceTenancy'])
-        self.vpc_id = vpc.get('Vpc').get('VpcId')
+        self.log("creating vpc under region {0}".format(config["region"]))
+        vpc = self.get_client().create_vpc(
+            CidrBlock=config["cidrBlock"], InstanceTenancy=config["instanceTenancy"]
+        )
+        self.vpc_id = vpc.get("Vpc").get("VpcId")
 
         with self.depl._db:
             self.state = self.STARTING
             self._state["vpcId"] = self.vpc_id
-            self._state["region"] = config['region']
-            self._state["cidrBlock"] = config['cidrBlock']
-            self._state["instanceTenancy"] = config['instanceTenancy']
+            self._state["region"] = config["region"]
+            self._state["cidrBlock"] = config["cidrBlock"]
+            self._state["instanceTenancy"] = config["instanceTenancy"]
 
         def tag_updater(tags):
-            self.get_client().create_tags(Resources=[self.vpc_id], Tags=[{"Key": k, "Value": tags[k]} for k in tags])
+            self.get_client().create_tags(
+                Resources=[self.vpc_id],
+                Tags=[{"Key": k, "Value": tags[k]} for k in tags],
+            )
 
         self.update_tags_using(tag_updater, user_tags=config["tags"], check=True)
 
@@ -167,77 +203,101 @@ class VPCState(nixops.resources.DiffEngineResourceState, EC2CommonState):
 
     def realize_classic_link_change(self, allow_recreate):
         config = self.get_defn()
-        if config['enableClassicLink']:
+        if config["enableClassicLink"]:
             self.get_client().enable_vpc_classic_link(VpcId=self.vpc_id)
-        elif config['enableClassicLink'] == False and self._state.get('enableClassicLink', None):
+        elif config["enableClassicLink"] == False and self._state.get(
+            "enableClassicLink", None
+        ):
             self.get_client().disable_vpc_classic_link(VpcId=self.vpc_id)
         with self.depl._db:
-            self._state["enableClassicLink"] = config['enableClassicLink']
+            self._state["enableClassicLink"] = config["enableClassicLink"]
 
     def realize_dns_config(self, allow_recreate):
         config = self.get_defn()
-        self.get_client().modify_vpc_attribute(VpcId=self.vpc_id,
-                                          EnableDnsSupport={
-                                              'Value': config['enableDnsSupport']
-                                              })
-        self.get_client().modify_vpc_attribute(VpcId=self.vpc_id,
-                                          EnableDnsHostnames={
-                                              'Value': config['enableDnsHostnames']
-                                              })
+        self.get_client().modify_vpc_attribute(
+            VpcId=self.vpc_id, EnableDnsSupport={"Value": config["enableDnsSupport"]}
+        )
+        self.get_client().modify_vpc_attribute(
+            VpcId=self.vpc_id,
+            EnableDnsHostnames={"Value": config["enableDnsHostnames"]},
+        )
         with self.depl._db:
-            self._state["enableDnsSupport"] = config['enableDnsSupport']
-            self._state["enableDnsHostnames"] = config['enableDnsHostnames']
+            self._state["enableDnsSupport"] = config["enableDnsSupport"]
+            self._state["enableDnsHostnames"] = config["enableDnsHostnames"]
 
     def wait_for_ipv6_cidr_association(self, association_id):
         def lookup_association(association_set):
             for assoc in association_set:
-                if association_id == assoc['AssociationId']:
+                if association_id == assoc["AssociationId"]:
                     return assoc
+
         while True:
             response = self.get_client().describe_vpcs(VpcIds=[self._state["vpcId"]])
-            if len(response['Vpcs']) == 1:
-                vpc = response['Vpcs'][0]
-                association = lookup_association(vpc['Ipv6CidrBlockAssociationSet'])
-                cidr_block_state = association['Ipv6CidrBlockState']['State']
+            if len(response["Vpcs"]) == 1:
+                vpc = response["Vpcs"][0]
+                association = lookup_association(vpc["Ipv6CidrBlockAssociationSet"])
+                cidr_block_state = association["Ipv6CidrBlockState"]["State"]
                 if cidr_block_state == "associated":
                     break
                 elif cidr_block_state != "associating":
-                    raise Exception("ipv6 cidr block association {0} is in an unexpected state {1}".format(
-                        association_id, cidr_block_state))
+                    raise Exception(
+                        "ipv6 cidr block association {0} is in an unexpected state {1}".format(
+                            association_id, cidr_block_state
+                        )
+                    )
 
                 self.log_continue(".")
                 time.sleep(1)
             else:
-                raise Exception("couldn't find vpc {}, please run a deploy with --check".format(self._state["vpcId"]))
+                raise Exception(
+                    "couldn't find vpc {}, please run a deploy with --check".format(
+                        self._state["vpcId"]
+                    )
+                )
         self.log_end(" done")
-        return association['Ipv6CidrBlock']
+        return association["Ipv6CidrBlock"]
 
     def realize_associate_ipv6_cidr_block(self, allow_recreate):
         config = self.get_defn()
-        assign_cidr = config['amazonProvidedIpv6CidrBlock']
+        assign_cidr = config["amazonProvidedIpv6CidrBlock"]
         if assign_cidr:
-            self.log("associating an amazon provided Ipv6 address to vpc {}".format(self._state["vpcId"]))
+            self.log(
+                "associating an amazon provided Ipv6 address to vpc {}".format(
+                    self._state["vpcId"]
+                )
+            )
             response = self.get_client().associate_vpc_cidr_block(
-                AmazonProvidedIpv6CidrBlock=config['amazonProvidedIpv6CidrBlock'],
-                VpcId=self._state["vpcId"])
-            association_id = response['Ipv6CidrBlockAssociation']['AssociationId']
+                AmazonProvidedIpv6CidrBlock=config["amazonProvidedIpv6CidrBlock"],
+                VpcId=self._state["vpcId"],
+            )
+            association_id = response["Ipv6CidrBlockAssociation"]["AssociationId"]
             cidr_block = self.wait_for_ipv6_cidr_association(association_id)
             self.log("generated Ipv6 cidr block: {}".format(cidr_block))
         else:
-            if self._state.get('associationId', None):
-                self.log("disassociating Ipv6 cidr block from vpc {}".format(self._state["vpcId"]))
+            if self._state.get("associationId", None):
+                self.log(
+                    "disassociating Ipv6 cidr block from vpc {}".format(
+                        self._state["vpcId"]
+                    )
+                )
                 self.get_client().disassociate_vpc_cidr_block(
-                    AssociationId=self._state['associationId'])
+                    AssociationId=self._state["associationId"]
+                )
 
         with self.depl._db:
-            self._state["amazonProvidedIpv6CidrBlock"] = config['amazonProvidedIpv6CidrBlock']
-            if assign_cidr: self._state['associationId'] = association_id
+            self._state["amazonProvidedIpv6CidrBlock"] = config[
+                "amazonProvidedIpv6CidrBlock"
+            ]
+            if assign_cidr:
+                self._state["associationId"] = association_id
 
     def realize_update_tag(self, allow_recreate):
         config = self.get_defn()
-        tags = config['tags']
+        tags = config["tags"]
         tags.update(self.get_common_tags())
-        self.get_client().create_tags(Resources=[self.vpc_id], Tags=[{"Key": k, "Value": tags[k]} for k in tags])
+        self.get_client().create_tags(
+            Resources=[self.vpc_id], Tags=[{"Key": k, "Value": tags[k]} for k in tags]
+        )
 
     def destroy(self, wipe=False):
         self._destroy()

--- a/nixopsaws/resources/vpc_customer_gateway.py
+++ b/nixopsaws/resources/vpc_customer_gateway.py
@@ -14,6 +14,7 @@ import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState
 import nixopsaws.ec2_utils
 
+
 class VPCCustomerGatewayDefinition(nixops.resources.ResourceDefinition):
     """Definition of a VPC customer gateway."""
 
@@ -31,15 +32,25 @@ class VPCCustomerGatewayDefinition(nixops.resources.ResourceDefinition):
 
 class VPCCustomerGatewayState(nixops.resources.DiffEngineResourceState, EC2CommonState):
     """State of a VPC customer gateway."""
-    state = nixops.util.attr_property("state", nixops.resources.DiffEngineResourceState.MISSING, int)
+
+    state = nixops.util.attr_property(
+        "state", nixops.resources.DiffEngineResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("accessKeyId", None)
     _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ["customerGatewayId"]
 
     def __init__(self, depl, name, id):
         nixops.resources.DiffEngineResourceState.__init__(self, depl, name, id)
         self._state = StateDict(depl, id)
-        self.handle_create_customer_gtw = Handler(['region', 'publicIp', 'bgpAsn', 'type'], handle=self.realize_create_customer_gtw)
-        self.handle_tag_update = Handler(['tags'], after=[self.handle_create_customer_gtw], handle=self.realize_update_tag)
+        self.handle_create_customer_gtw = Handler(
+            ["region", "publicIp", "bgpAsn", "type"],
+            handle=self.realize_create_customer_gtw,
+        )
+        self.handle_tag_update = Handler(
+            ["tags"],
+            after=[self.handle_create_customer_gtw],
+            handle=self.realize_update_tag,
+        )
 
     @classmethod
     def get_type(cls):
@@ -47,15 +58,16 @@ class VPCCustomerGatewayState(nixops.resources.DiffEngineResourceState, EC2Commo
 
     def show_type(self):
         s = super(VPCCustomerGatewayState, self).show_type()
-        if self._state.get('region', None): s = "{0} [{1}]".format(s, self._state['region'])
+        if self._state.get("region", None):
+            s = "{0} [{1}]".format(s, self._state["region"])
         return s
 
     @property
     def resource_id(self):
-        return self._state.get('customerGatewayId', None)
+        return self._state.get("customerGatewayId", None)
 
     def prefix_definition(self, attr):
-        return {('resources', 'vpcCustomerGateways'): attr}
+        return {("resources", "vpcCustomerGateways"): attr}
 
     def get_defintion_prefix(self):
         return "resources.vpcCustomerGateways."
@@ -64,59 +76,74 @@ class VPCCustomerGatewayState(nixops.resources.DiffEngineResourceState, EC2Commo
         config = self.get_defn()
         if self.state == self.UP:
             if not allow_recreate:
-                raise Exception("customer gateway {} defintion changed"
-                                " use --allow-recreate if you want to create a new one".format(
-                                    self._state['customerGatewayId']))
+                raise Exception(
+                    "customer gateway {} defintion changed"
+                    " use --allow-recreate if you want to create a new one".format(
+                        self._state["customerGatewayId"]
+                    )
+                )
             self.warn("customer gateway changed, recreating...")
             self._destroy()
 
-        self._state['region'] = config['region']
+        self._state["region"] = config["region"]
 
         self.log("creating customer gateway")
         response = self.get_client().create_customer_gateway(
-            BgpAsn=config['bgpAsn'],
-            PublicIp=config['publicIp'],
-            Type=config['type'])
+            BgpAsn=config["bgpAsn"], PublicIp=config["publicIp"], Type=config["type"]
+        )
 
-        customer_gtw_id = response['CustomerGateway']['CustomerGatewayId']
-        with self.depl._db: self.state = self.STARTING
+        customer_gtw_id = response["CustomerGateway"]["CustomerGatewayId"]
+        with self.depl._db:
+            self.state = self.STARTING
 
-        waiter = self.get_client().get_waiter('customer_gateway_available')
+        waiter = self.get_client().get_waiter("customer_gateway_available")
         waiter.wait(CustomerGatewayIds=[customer_gtw_id])
 
         with self.depl._db:
             self.state = self.UP
-            self._state['region'] = config['region']
-            self._state['customerGatewayId'] = customer_gtw_id
-            self._state['bgpAsn'] = config['bgpAsn']
-            self._state['publicIp'] = config['publicIp']
-            self._state['type'] = config['type']
+            self._state["region"] = config["region"]
+            self._state["customerGatewayId"] = customer_gtw_id
+            self._state["bgpAsn"] = config["bgpAsn"]
+            self._state["publicIp"] = config["publicIp"]
+            self._state["type"] = config["type"]
 
     def realize_update_tag(self, allow_recreate):
         config = self.get_defn()
-        tags = config['tags']
+        tags = config["tags"]
         tags.update(self.get_common_tags())
-        self.get_client().create_tags(Resources=[self._state['customerGatewayId']], Tags=[{"Key": k, "Value": tags[k]} for k in tags])
+        self.get_client().create_tags(
+            Resources=[self._state["customerGatewayId"]],
+            Tags=[{"Key": k, "Value": tags[k]} for k in tags],
+        )
 
     def _destroy(self):
-        if self.state != self.UP: return
-        self.log("deleting customer gateway {}".format(self._state['customerGatewayId']))
+        if self.state != self.UP:
+            return
+        self.log(
+            "deleting customer gateway {}".format(self._state["customerGatewayId"])
+        )
         try:
-            self.get_client().delete_customer_gateway(CustomerGatewayId=self._state['customerGatewayId'])
+            self.get_client().delete_customer_gateway(
+                CustomerGatewayId=self._state["customerGatewayId"]
+            )
         except botocore.exceptions.ClientError as e:
-            if e.response['Error']['Code'] == "InvalidCustomerGatewayID.NotFound":
-                self.warn("customer gateway {} was already deleted".format(self._state['customerGatewayId']))
+            if e.response["Error"]["Code"] == "InvalidCustomerGatewayID.NotFound":
+                self.warn(
+                    "customer gateway {} was already deleted".format(
+                        self._state["customerGatewayId"]
+                    )
+                )
             else:
                 raise e
 
-        #TODO wait for customer gtw to be deleted
+        # TODO wait for customer gtw to be deleted
         with self.depl._db:
             self.state = self.MISSING
-            self._state['region'] = None
-            self._state['customerGatewayId'] = None
-            self._state['bgpAsn'] = None
-            self._state['publicIp'] = None
-            self._state['type'] = None
+            self._state["region"] = None
+            self._state["customerGatewayId"] = None
+            self._state["bgpAsn"] = None
+            self._state["publicIp"] = None
+            self._state["type"] = None
 
     def destroy(self, wipe=False):
         self._destroy()

--- a/nixopsaws/resources/vpc_dhcp_options.py
+++ b/nixopsaws/resources/vpc_dhcp_options.py
@@ -15,6 +15,7 @@ import nixopsaws.ec2_utils
 from nixops.state import StateDict
 from nixops.diff import Diff, Handler
 
+
 class VPCDhcpOptionsDefinition(nixops.resources.ResourceDefinition):
     """Definition of a VPC DHCP options."""
 
@@ -29,12 +30,15 @@ class VPCDhcpOptionsDefinition(nixops.resources.ResourceDefinition):
     def show_type(self):
         return "{0}".format(self.get_type())
 
+
 class VPCDhcpOptionsState(nixops.resources.DiffEngineResourceState, EC2CommonState):
     """State of a VPC DHCP options."""
 
-    state = nixops.util.attr_property("state", nixops.resources.DiffEngineResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.DiffEngineResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("accessKeyId", None)
-    _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ['dhcpOptionsId']
+    _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ["dhcpOptionsId"]
 
     @classmethod
     def get_type(cls):
@@ -43,22 +47,37 @@ class VPCDhcpOptionsState(nixops.resources.DiffEngineResourceState, EC2CommonSta
     def __init__(self, depl, name, id):
         nixops.resources.DiffEngineResourceState.__init__(self, depl, name, id)
         self._state = StateDict(depl, id)
-        handled_keys=['region', 'vpcId', 'domainNameServers', 'domainName', 'ntpServers', 'netbiosNameServers', 'netbiosNodeType']
-        self.handle_create_dhcp_options = Handler(handled_keys, handle=self.realize_create_dhcp_options)
-        self.handle_tag_update = Handler(['tags'], after=[self.handle_create_dhcp_options], handle=self.realize_update_tag)
+        handled_keys = [
+            "region",
+            "vpcId",
+            "domainNameServers",
+            "domainName",
+            "ntpServers",
+            "netbiosNameServers",
+            "netbiosNodeType",
+        ]
+        self.handle_create_dhcp_options = Handler(
+            handled_keys, handle=self.realize_create_dhcp_options
+        )
+        self.handle_tag_update = Handler(
+            ["tags"],
+            after=[self.handle_create_dhcp_options],
+            handle=self.realize_update_tag,
+        )
 
     def show_type(self):
         s = super(VPCDhcpOptionsState, self).show_type()
-        region = self._state.get('region', None)
-        if region: s = "{0} [{1}]".format(s, region)
+        region = self._state.get("region", None)
+        if region:
+            s = "{0} [{1}]".format(s, region)
         return s
 
     @property
     def resource_id(self):
-        return self._state.get('dhcpOptionsId', None)
+        return self._state.get("dhcpOptionsId", None)
 
     def prefix_definition(self, attr):
-        return {('resources', 'vpcDhcpOptions'): attr}
+        return {("resources", "vpcDhcpOptions"): attr}
 
     def get_physical_spec(self):
         return {}
@@ -67,93 +86,108 @@ class VPCDhcpOptionsState(nixops.resources.DiffEngineResourceState, EC2CommonSta
         return "resources.vpcDhcpOptions."
 
     def create_after(self, resources, defn):
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.vpc.VPCState)}
+        return {r for r in resources if isinstance(r, nixopsaws.resources.vpc.VPCState)}
 
     def get_dhcp_config_option(self, key, values):
-        val = values if isinstance(values, list) else [ str(values) ]
-        return {'Key': key, 'Values': val}
+        val = values if isinstance(values, list) else [str(values)]
+        return {"Key": key, "Values": val}
 
     def generate_dhcp_configuration(self, config):
         configuration = []
 
         def check_and_append(option, key):
             if config[option]:
-                configuration.append(self.get_dhcp_config_option(key=key, values=config[option]))
+                configuration.append(
+                    self.get_dhcp_config_option(key=key, values=config[option])
+                )
 
-        check_and_append('domainNameServers', 'domain-name-servers')
-        check_and_append('domainName', 'domain-name')
-        check_and_append('ntpServers', 'ntp-servers')
-        check_and_append('netbiosNameServers', 'netbios-name-servers')
-        check_and_append('netbiosNodeType', 'netbios-node-type')
+        check_and_append("domainNameServers", "domain-name-servers")
+        check_and_append("domainName", "domain-name")
+        check_and_append("ntpServers", "ntp-servers")
+        check_and_append("netbiosNameServers", "netbios-name-servers")
+        check_and_append("netbiosNodeType", "netbios-node-type")
         return configuration
 
     def realize_create_dhcp_options(self, allow_recreate):
         config = self.get_defn()
         if self.state == (self.UP or self.STARTING):
             if not allow_recreate:
-                raise Exception("to recreate the dhcp options please add --allow-recreate"
-                                " to the deploy command")
+                raise Exception(
+                    "to recreate the dhcp options please add --allow-recreate"
+                    " to the deploy command"
+                )
             self.warn("the dhcp options {} will be destroyed and re-created")
             self._destroy()
 
-        self._state['region'] = config['region']
-        vpc_id = config['vpcId']
+        self._state["region"] = config["region"]
+        vpc_id = config["vpcId"]
         if vpc_id.startswith("res-"):
             res = self.depl.get_typed_resource(vpc_id[4:].split(".")[0], "vpc")
-            vpc_id = res._state['vpcId']
+            vpc_id = res._state["vpcId"]
 
         dhcp_config = self.generate_dhcp_configuration(config)
 
         def create_dhcp_options(dhcp_config):
             self.log("creating dhcp options...")
-            response = self.get_client().create_dhcp_options(DhcpConfigurations=dhcp_config)
-            return response.get('DhcpOptions').get('DhcpOptionsId')
+            response = self.get_client().create_dhcp_options(
+                DhcpConfigurations=dhcp_config
+            )
+            return response.get("DhcpOptions").get("DhcpOptionsId")
 
         dhcp_options_id = create_dhcp_options(dhcp_config)
         with self.depl._db:
             self.state = self.STARTING
-            self._state['vpcId'] = vpc_id
-            self._state['dhcpOptionsId'] = dhcp_options_id
-            self._state['domainName'] = config["domainName"]
-            self._state['domainNameServers'] = config["domainNameServers"]
-            self._state['ntpServers'] = config["ntpServers"]
-            self._state['netbiosNameServers'] = config["netbiosNameServers"]
-            self._state['netbiosNodeType'] = config["netbiosNodeType"]
+            self._state["vpcId"] = vpc_id
+            self._state["dhcpOptionsId"] = dhcp_options_id
+            self._state["domainName"] = config["domainName"]
+            self._state["domainNameServers"] = config["domainNameServers"]
+            self._state["ntpServers"] = config["ntpServers"]
+            self._state["netbiosNameServers"] = config["netbiosNameServers"]
+            self._state["netbiosNodeType"] = config["netbiosNodeType"]
 
-        self.get_client().associate_dhcp_options(DhcpOptionsId=dhcp_options_id, VpcId=vpc_id)
+        self.get_client().associate_dhcp_options(
+            DhcpOptionsId=dhcp_options_id, VpcId=vpc_id
+        )
         with self.depl._db:
             self.state = self.UP
 
     def realize_update_tag(self, allow_recreate):
         config = self.get_defn()
-        tags = config['tags']
+        tags = config["tags"]
         tags.update(self.get_common_tags())
-        self.get_client().create_tags(Resources=[self._state['dhcpOptionsId']], Tags=[{"Key": k, "Value": tags[k]} for k in tags])
+        self.get_client().create_tags(
+            Resources=[self._state["dhcpOptionsId"]],
+            Tags=[{"Key": k, "Value": tags[k]} for k in tags],
+        )
 
     def _destroy(self):
-        if self.state != self.UP: return
-        dhcp_options_id = self._state.get('dhcpOptionsId', None)
+        if self.state != self.UP:
+            return
+        dhcp_options_id = self._state.get("dhcpOptionsId", None)
         if dhcp_options_id:
             self.log("deleting dhcp options {0}".format(dhcp_options_id))
             try:
-                self.get_client().associate_dhcp_options(DhcpOptionsId='default', VpcId=self._state['vpcId'])
+                self.get_client().associate_dhcp_options(
+                    DhcpOptionsId="default", VpcId=self._state["vpcId"]
+                )
                 self.get_client().delete_dhcp_options(DhcpOptionsId=dhcp_options_id)
             except botocore.exceptions.ClientError as e:
-                if e.response['Error']['Code'] == 'InvalidDhcpOptionsID.NotFound':
-                    self.warn("dhcp options {0} was already deleted".format(dhcp_options_id))
+                if e.response["Error"]["Code"] == "InvalidDhcpOptionsID.NotFound":
+                    self.warn(
+                        "dhcp options {0} was already deleted".format(dhcp_options_id)
+                    )
                 else:
                     raise e
 
             with self.depl._db:
                 self.state = self.MISSING
-                self._state['vpcId'] = None
-                self._state['dhcpOptions'] = None
-                self._state['domainName'] = None
-                self._state['domainNameServers'] = None
-                self._state['ntpServers'] = None
-                self._state['netbiosNameServers'] = None
-                self._state['netbiosNodeType'] = None
+                self._state["vpcId"] = None
+                self._state["dhcpOptions"] = None
+                self._state["domainName"] = None
+                self._state["domainNameServers"] = None
+                self._state["ntpServers"] = None
+                self._state["netbiosNameServers"] = None
+                self._state["netbiosNodeType"] = None
 
     def destroy(self, wipe=False):
         self._destroy()

--- a/nixopsaws/resources/vpc_egress_only_internet_gateway.py
+++ b/nixopsaws/resources/vpc_egress_only_internet_gateway.py
@@ -10,6 +10,7 @@ import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState
 import nixopsaws.ec2_utils
 
+
 class VPCEgressOnlyInternetGatewayDefinition(nixops.resources.ResourceDefinition):
     """Definition of a VPC egress only internet gateway."""
 
@@ -25,16 +26,25 @@ class VPCEgressOnlyInternetGatewayDefinition(nixops.resources.ResourceDefinition
         return "{0}".format(self.get_type())
 
 
-class VPCEgressOnlyInternetGatewayState(nixops.resources.DiffEngineResourceState, EC2CommonState):
+class VPCEgressOnlyInternetGatewayState(
+    nixops.resources.DiffEngineResourceState, EC2CommonState
+):
     """State of a VPC egress only internet gateway."""
-    state = nixops.util.attr_property("state", nixops.resources.DiffEngineResourceState.MISSING, int)
+
+    state = nixops.util.attr_property(
+        "state", nixops.resources.DiffEngineResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("accessKeyId", None)
-    _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ["egressOnlyInternetGatewayId"]
+    _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + [
+        "egressOnlyInternetGatewayId"
+    ]
 
     def __init__(self, depl, name, id):
         nixops.resources.DiffEngineResourceState.__init__(self, depl, name, id)
         self._state = StateDict(depl, id)
-        self.handle_create_igw = Handler(['region', 'vpcId'], handle=self.realize_create_gtw)
+        self.handle_create_igw = Handler(
+            ["region", "vpcId"], handle=self.realize_create_gtw
+        )
 
     @classmethod
     def get_type(cls):
@@ -42,62 +52,80 @@ class VPCEgressOnlyInternetGatewayState(nixops.resources.DiffEngineResourceState
 
     def show_type(self):
         s = super(VPCEgressOnlyInternetGatewayState, self).show_type()
-        if self._state.get('region', None): s = "{0} [{1}]".format(s, self._state['region'])
+        if self._state.get("region", None):
+            s = "{0} [{1}]".format(s, self._state["region"])
         return s
 
     @property
     def resource_id(self):
-        return self._state.get('egressOnlyInternetGatewayId', None)
+        return self._state.get("egressOnlyInternetGatewayId", None)
 
     def prefix_definition(self, attr):
-        return {('resources', 'vpcEgressOnlyInternetGateways'): attr}
+        return {("resources", "vpcEgressOnlyInternetGateways"): attr}
 
     def get_defintion_prefix(self):
         return "resources.vpcEgressOnlyInternetGateways."
 
     def create_after(self, resources, defn):
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.vpc.VPCState) or
-                isinstance(r, nixopsaws.resources.elastic_ip.ElasticIPState)}
+        return {
+            r
+            for r in resources
+            if isinstance(r, nixopsaws.resources.vpc.VPCState)
+            or isinstance(r, nixopsaws.resources.elastic_ip.ElasticIPState)
+        }
 
     def realize_create_gtw(self, allow_recreate):
         config = self.get_defn()
 
         if self.state == self.UP:
             if not allow_recreate:
-                raise Exception("egress only internet gateway {} defintion changed"
-                                " use --allow-recreate if you want to create a new one".format(
-                                    self._state['egressOnlyInternetGatewayId']))
+                raise Exception(
+                    "egress only internet gateway {} defintion changed"
+                    " use --allow-recreate if you want to create a new one".format(
+                        self._state["egressOnlyInternetGatewayId"]
+                    )
+                )
             self.warn("egress only internet gateway changed, recreating...")
             self._destroy()
 
-        self._state['region'] = config['region']
+        self._state["region"] = config["region"]
 
-        vpc_id = config['vpcId']
+        vpc_id = config["vpcId"]
         if vpc_id.startswith("res-"):
             res = self.depl.get_typed_resource(vpc_id[4:].split(".")[0], "vpc")
-            vpc_id = res._state['vpcId']
+            vpc_id = res._state["vpcId"]
 
-        self.log("creating egress only internet gateway in region {0}, vpc {1}".format(self._state['region'], vpc_id))
+        self.log(
+            "creating egress only internet gateway in region {0}, vpc {1}".format(
+                self._state["region"], vpc_id
+            )
+        )
         response = self.get_client().create_egress_only_internet_gateway(VpcId=vpc_id)
-        igw_id = response['EgressOnlyInternetGateway']['EgressOnlyInternetGatewayId']
+        igw_id = response["EgressOnlyInternetGateway"]["EgressOnlyInternetGatewayId"]
 
         with self.depl._db:
             self.state = self.UP
-            self._state['region'] = config['region']
-            self._state['vpcId'] = vpc_id
-            self._state['egressOnlyInternetGatewayId'] = igw_id
+            self._state["region"] = config["region"]
+            self._state["vpcId"] = vpc_id
+            self._state["egressOnlyInternetGatewayId"] = igw_id
 
     def _destroy(self):
-        if self.state != self.UP: return
-        self.log("deleting egress only internet gateway {0}".format(self._state['egressOnlyInternetGatewayId']))
-        self.get_client().delete_egress_only_internet_gateway(EgressOnlyInternetGatewayId=self._state['egressOnlyInternetGatewayId'])
+        if self.state != self.UP:
+            return
+        self.log(
+            "deleting egress only internet gateway {0}".format(
+                self._state["egressOnlyInternetGatewayId"]
+            )
+        )
+        self.get_client().delete_egress_only_internet_gateway(
+            EgressOnlyInternetGatewayId=self._state["egressOnlyInternetGatewayId"]
+        )
 
         with self.depl._db:
             self.state = self.MISSING
-            self._state['region'] = None
-            self._state['vpcId'] = None
-            self._state['egressOnlyInternetGatewayId'] = None
+            self._state["region"] = None
+            self._state["vpcId"] = None
+            self._state["egressOnlyInternetGatewayId"] = None
 
     def destroy(self, wipe=False):
         self._destroy()

--- a/nixopsaws/resources/vpc_endpoint.py
+++ b/nixopsaws/resources/vpc_endpoint.py
@@ -9,6 +9,7 @@ import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState
 import nixopsaws.ec2_utils
 
+
 class VPCEndpointDefinition(nixops.resources.ResourceDefinition):
     """Definition of a VPC endpoint."""
 
@@ -23,19 +24,30 @@ class VPCEndpointDefinition(nixops.resources.ResourceDefinition):
     def show_type(self):
         return "{0}".format(self.get_type())
 
+
 class VPCEndpointState(nixops.resources.DiffEngineResourceState, EC2CommonState):
     """State of a VPC endpoint."""
-    state = nixops.util.attr_property("state", nixops.resources.DiffEngineResourceState.MISSING, int)
+
+    state = nixops.util.attr_property(
+        "state", nixops.resources.DiffEngineResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("accessKeyId", None)
-    _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ["endpointId","creationToken"]
+    _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + [
+        "endpointId",
+        "creationToken",
+    ]
 
     def __init__(self, depl, name, id):
         nixops.resources.DiffEngineResourceState.__init__(self, depl, name, id)
         self._state = StateDict(depl, id)
-        self.handle_create_endpoint = Handler(['region', 'serviceName', 'vpcId'], handle=self.realize_create_endpoint)
-        self.handle_modify_endpoint = Handler(['policy', 'routeTableIds'],
-                after=[self.handle_create_endpoint],
-                handle=self.realize_modify_endpoint)
+        self.handle_create_endpoint = Handler(
+            ["region", "serviceName", "vpcId"], handle=self.realize_create_endpoint
+        )
+        self.handle_modify_endpoint = Handler(
+            ["policy", "routeTableIds"],
+            after=[self.handle_create_endpoint],
+            handle=self.realize_modify_endpoint,
+        )
 
     @classmethod
     def get_type(cls):
@@ -43,102 +55,120 @@ class VPCEndpointState(nixops.resources.DiffEngineResourceState, EC2CommonState)
 
     def show_type(self):
         s = super(VPCEndpointState, self).show_type()
-        if self._state.get('region', None): s = "{0} [{1}]".format(s, self._state['region'])
+        if self._state.get("region", None):
+            s = "{0} [{1}]".format(s, self._state["region"])
         return s
 
     @property
     def resource_id(self):
-        return self._state.get('endpointId', None)
+        return self._state.get("endpointId", None)
 
     def prefix_definition(self, attr):
-        return {('resources', 'vpcEndpoints'): attr}
+        return {("resources", "vpcEndpoints"): attr}
 
     def get_defintion_prefix(self):
         return "resources.vpcEndpoints"
 
     def create_after(self, resources, defn):
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.vpc.VPCState) or
-                isinstance(r, nixopsaws.resources.vpc_route_table.VPCRouteTableState)}
+        return {
+            r
+            for r in resources
+            if isinstance(r, nixopsaws.resources.vpc.VPCState)
+            or isinstance(r, nixopsaws.resources.vpc_route_table.VPCRouteTableState)
+        }
 
     def realize_create_endpoint(self, allow_recreate):
         config = self.get_defn()
         if self.state == self.UP:
             if not allow_recreate:
-                raise Exception("vpc endpoint {} definition changed"
-                                " use --allow-recreate if you want to create a new one".format(
-                                    self._state['endpointId']))
+                raise Exception(
+                    "vpc endpoint {} definition changed"
+                    " use --allow-recreate if you want to create a new one".format(
+                        self._state["endpointId"]
+                    )
+                )
             self.warn("vpc endpoint changed, recreating...")
             self._destroy()
 
-        self._state['region'] = config['region']
+        self._state["region"] = config["region"]
 
-        vpc_id = config['vpcId']
+        vpc_id = config["vpcId"]
 
         if vpc_id.startswith("res-"):
             res = self.depl.get_typed_resource(vpc_id[4:].split(".")[0], "vpc")
             vpc_id = res._state["vpcId"]
 
-        if not self._state.get('creationToken', None):
-            self._state['creationToken'] = str(uuid.uuid4())
+        if not self._state.get("creationToken", None):
+            self._state["creationToken"] = str(uuid.uuid4())
             self.state = self.STARTING
 
         response = self.get_client().create_vpc_endpoint(
-            ClientToken=self._state['creationToken'],
-            ServiceName=config['serviceName'],
-            VpcId=vpc_id)
+            ClientToken=self._state["creationToken"],
+            ServiceName=config["serviceName"],
+            VpcId=vpc_id,
+        )
 
-        endpoint_id = response['VpcEndpoint']['VpcEndpointId']
+        endpoint_id = response["VpcEndpoint"]["VpcEndpointId"]
         with self.depl._db:
             self.state = self.UP
-            self._state['endpointId'] = endpoint_id
-            self._state['vpcId'] = vpc_id
-            self._state['serviceName'] = config['serviceName']
+            self._state["endpointId"] = endpoint_id
+            self._state["vpcId"] = vpc_id
+            self._state["serviceName"] = config["serviceName"]
 
     def realize_modify_endpoint(self, allow_recreate):
         config = self.get_defn()
-        old_rtbs = self._state.get('routeTableIds', [])
+        old_rtbs = self._state.get("routeTableIds", [])
         new_rtbs = []
         for rtb in config["routeTableIds"]:
             if rtb.startswith("res-"):
-               res = self.depl.get_typed_resource(rtb[4:].split(".")[0], "vpc-route-table")
-               new_rtbs.append(res._state['routeTableId'])
+                res = self.depl.get_typed_resource(
+                    rtb[4:].split(".")[0], "vpc-route-table"
+                )
+                new_rtbs.append(res._state["routeTableId"])
             else:
-               new_rtbs.append(rtb)
+                new_rtbs.append(rtb)
 
         to_remove = [r for r in old_rtbs if r not in new_rtbs]
         to_add = [r for r in new_rtbs if r not in old_rtbs]
 
         edp_input = dict()
-        edp_input['AddRouteTableIds'] = to_add
-        edp_input['RemoveRouteTableIds'] = to_remove
-        if config['policy'] is not None: edp_input['PolicyDocument'] = config['policy']
-        edp_input['VpcEndpointId'] = self._state['endpointId']
+        edp_input["AddRouteTableIds"] = to_add
+        edp_input["RemoveRouteTableIds"] = to_remove
+        if config["policy"] is not None:
+            edp_input["PolicyDocument"] = config["policy"]
+        edp_input["VpcEndpointId"] = self._state["endpointId"]
 
         self.get_client().modify_vpc_endpoint(**edp_input)
 
         with self.depl._db:
-            self._state['policy'] = config['policy']
-            self._state['routeTableIds'] = new_rtbs
+            self._state["policy"] = config["policy"]
+            self._state["routeTableIds"] = new_rtbs
 
     def _destroy(self):
-        if self.state != self.UP: return
+        if self.state != self.UP:
+            return
         try:
-            self.log("deleting vpc endpoint {}".format(self._state['endpointId']))
-            self.get_client().delete_vpc_endpoints(VpcEndpointIds=[self._state['endpointId']])
+            self.log("deleting vpc endpoint {}".format(self._state["endpointId"]))
+            self.get_client().delete_vpc_endpoints(
+                VpcEndpointIds=[self._state["endpointId"]]
+            )
         except botocore.exceptions.ClientError as e:
-            if e.response['Error']['Code'] == 'InvalidVpcEndpointId.NotFound':
-                self.warn("vpc endpoint {} was already deleted".format(self._state['endpointId']))
+            if e.response["Error"]["Code"] == "InvalidVpcEndpointId.NotFound":
+                self.warn(
+                    "vpc endpoint {} was already deleted".format(
+                        self._state["endpointId"]
+                    )
+                )
             else:
                 raise e
 
         with self.depl._db:
             self.state = self.MISSING
-            self._state['endpointId'] = None
-            self._state['vpcId'] = None
-            self._state['serviceName'] = None
-            self._state['policy'] = None
-            self._state['routeTableIds'] = None
+            self._state["endpointId"] = None
+            self._state["vpcId"] = None
+            self._state["serviceName"] = None
+            self._state["policy"] = None
+            self._state["routeTableIds"] = None
 
     def destroy(self, wipe=False):
         self._destroy()

--- a/nixopsaws/resources/vpc_internet_gateway.py
+++ b/nixopsaws/resources/vpc_internet_gateway.py
@@ -14,6 +14,7 @@ import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState
 import nixopsaws.ec2_utils
 
+
 class VPCInternetGatewayDefinition(nixops.resources.ResourceDefinition):
     """Definition of a VPC internet gateway."""
 
@@ -31,15 +32,22 @@ class VPCInternetGatewayDefinition(nixops.resources.ResourceDefinition):
 
 class VPCInternetGatewayState(nixops.resources.DiffEngineResourceState, EC2CommonState):
     """State of a VPC internet gateway."""
-    state = nixops.util.attr_property("state", nixops.resources.DiffEngineResourceState.MISSING, int)
+
+    state = nixops.util.attr_property(
+        "state", nixops.resources.DiffEngineResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("accessKeyId", None)
     _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ["internetGatewayId"]
 
     def __init__(self, depl, name, id):
         nixops.resources.DiffEngineResourceState.__init__(self, depl, name, id)
         self._state = StateDict(depl, id)
-        self.handle_create_igw = Handler(['region', 'vpcId'], handle=self.realize_create_gtw)
-        self.handle_tag_update = Handler(['tags'], after=[self.handle_create_igw], handle=self.realize_update_tag)
+        self.handle_create_igw = Handler(
+            ["region", "vpcId"], handle=self.realize_create_gtw
+        )
+        self.handle_tag_update = Handler(
+            ["tags"], after=[self.handle_create_igw], handle=self.realize_update_tag
+        )
 
     @classmethod
     def get_type(cls):
@@ -47,74 +55,97 @@ class VPCInternetGatewayState(nixops.resources.DiffEngineResourceState, EC2Commo
 
     def show_type(self):
         s = super(VPCInternetGatewayState, self).show_type()
-        if self._state.get('region', None): s = "{0} [{1}]".format(s, self._state['region'])
+        if self._state.get("region", None):
+            s = "{0} [{1}]".format(s, self._state["region"])
         return s
 
     @property
     def resource_id(self):
-        return self._state.get('internetGatewayId', None)
+        return self._state.get("internetGatewayId", None)
 
     def prefix_definition(self, attr):
-        return {('resources', 'vpcInternetGateways'): attr}
+        return {("resources", "vpcInternetGateways"): attr}
 
     def get_defintion_prefix(self):
         return "resources.vpcInternetGateways."
 
     def create_after(self, resources, defn):
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.vpc.VPCState) or
-                isinstance(r, nixopsaws.resources.elastic_ip.ElasticIPState)}
+        return {
+            r
+            for r in resources
+            if isinstance(r, nixopsaws.resources.vpc.VPCState)
+            or isinstance(r, nixopsaws.resources.elastic_ip.ElasticIPState)
+        }
 
     def realize_create_gtw(self, allow_recreate):
         config = self.get_defn()
 
         if self.state == self.UP:
             if not allow_recreate:
-                raise Exception("internet gateway {} defintion changed"
-                                " use --allow-recreate if you want to create a new one".format(
-                                    self._state['internetGatewayId']))
+                raise Exception(
+                    "internet gateway {} defintion changed"
+                    " use --allow-recreate if you want to create a new one".format(
+                        self._state["internetGatewayId"]
+                    )
+                )
             self.warn("internet gateway changed, recreating...")
             self._destroy()
 
-        self._state['region'] = config['region']
+        self._state["region"] = config["region"]
 
-        vpc_id = config['vpcId']
+        vpc_id = config["vpcId"]
         if vpc_id.startswith("res-"):
             res = self.depl.get_typed_resource(vpc_id[4:].split(".")[0], "vpc")
-            vpc_id = res._state['vpcId']
+            vpc_id = res._state["vpcId"]
 
-        self.log("creating internet gateway in region {}".format(self._state['region']))
+        self.log("creating internet gateway in region {}".format(self._state["region"]))
         response = self.get_client().create_internet_gateway()
-        igw_id = response['InternetGateway']['InternetGatewayId']
+        igw_id = response["InternetGateway"]["InternetGatewayId"]
         self.log("attaching internet gateway {0} to vpc {1}".format(igw_id, vpc_id))
-        self.get_client().attach_internet_gateway(InternetGatewayId=igw_id,
-                                             VpcId=vpc_id)
+        self.get_client().attach_internet_gateway(
+            InternetGatewayId=igw_id, VpcId=vpc_id
+        )
         with self.depl._db:
             self.state = self.UP
-            self._state['region'] = config['region']
-            self._state['vpcId'] = vpc_id
-            self._state['internetGatewayId'] = igw_id
+            self._state["region"] = config["region"]
+            self._state["vpcId"] = vpc_id
+            self._state["internetGatewayId"] = igw_id
 
     def realize_update_tag(self, allow_recreate):
         config = self.get_defn()
-        tags = config['tags']
+        tags = config["tags"]
         tags.update(self.get_common_tags())
-        self.get_client().create_tags(Resources=[self._state['internetGatewayId']], Tags=[{"Key": k, "Value": tags[k]} for k in tags])
+        self.get_client().create_tags(
+            Resources=[self._state["internetGatewayId"]],
+            Tags=[{"Key": k, "Value": tags[k]} for k in tags],
+        )
 
     def _destroy(self):
-        if self.state != self.UP: return
-        self.log("detaching internet gateway {0} from vpc {1}".format(self._state['internetGatewayId'],
-            self._state['vpcId']))
-        self._retry(lambda: self.get_client().detach_internet_gateway(InternetGatewayId=self._state['internetGatewayId'],
-                VpcId=self._state['vpcId']))
-        self.log("deleting internet gateway {0}".format(self._state['internetGatewayId']))
-        self.get_client().delete_internet_gateway(InternetGatewayId=self._state['internetGatewayId'])
+        if self.state != self.UP:
+            return
+        self.log(
+            "detaching internet gateway {0} from vpc {1}".format(
+                self._state["internetGatewayId"], self._state["vpcId"]
+            )
+        )
+        self._retry(
+            lambda: self.get_client().detach_internet_gateway(
+                InternetGatewayId=self._state["internetGatewayId"],
+                VpcId=self._state["vpcId"],
+            )
+        )
+        self.log(
+            "deleting internet gateway {0}".format(self._state["internetGatewayId"])
+        )
+        self.get_client().delete_internet_gateway(
+            InternetGatewayId=self._state["internetGatewayId"]
+        )
 
         with self.depl._db:
             self.state = self.MISSING
-            self._state['region'] = None
-            self._state['vpcId'] = None
-            self._state['internetGatewayId'] = None
+            self._state["region"] = None
+            self._state["vpcId"] = None
+            self._state["internetGatewayId"] = None
 
     def destroy(self, wipe=False):
         self._destroy()

--- a/nixopsaws/resources/vpc_nat_gateway.py
+++ b/nixopsaws/resources/vpc_nat_gateway.py
@@ -15,6 +15,7 @@ import nixopsaws.ec2_utils
 from nixops.diff import Diff, Handler
 from nixops.state import StateDict
 
+
 class VPCNatGatewayDefinition(nixops.resources.ResourceDefinition):
     """Definition of a VPC NAT gateway"""
 
@@ -29,12 +30,18 @@ class VPCNatGatewayDefinition(nixops.resources.ResourceDefinition):
     def show_type(self):
         return "{0}".format(self.get_type())
 
+
 class VPCNatGatewayState(nixops.resources.DiffEngineResourceState, EC2CommonState):
     """State of a VPC NAT gateway"""
 
-    state = nixops.util.attr_property("state", nixops.resources.DiffEngineResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.DiffEngineResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("accessKeyId", None)
-    _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ['natGatewayId', 'creationToken']
+    _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + [
+        "natGatewayId",
+        "creationToken",
+    ]
 
     @classmethod
     def get_type(cls):
@@ -43,89 +50,120 @@ class VPCNatGatewayState(nixops.resources.DiffEngineResourceState, EC2CommonStat
     def __init__(self, depl, name, id):
         nixops.resources.DiffEngineResourceState.__init__(self, depl, name, id)
         self._state = StateDict(depl, id)
-        self.region = self._state.get('region', None)
-        self.handle_create_gtw = Handler(['region', 'subnetId', 'allocationId'], handle=self.realize_create_gtw)
-        self.nat_gtw_id = self._state.get('natGatewayId', None)
+        self.region = self._state.get("region", None)
+        self.handle_create_gtw = Handler(
+            ["region", "subnetId", "allocationId"], handle=self.realize_create_gtw
+        )
+        self.nat_gtw_id = self._state.get("natGatewayId", None)
 
     def show_type(self):
         s = super(VPCNatGatewayState, self).show_type()
-        if self.region: s = "{0} [{1}]".format(s, self.region)
+        if self.region:
+            s = "{0} [{1}]".format(s, self.region)
         return s
 
     @property
     def resource_id(self):
-        return self._state.get('natGatewayId', None)
+        return self._state.get("natGatewayId", None)
 
     def prefix_definition(self, attr):
-        return {('resources', 'vpcNatGateways'): attr}
+        return {("resources", "vpcNatGateways"): attr}
 
     def get_physical_spec(self):
-        return { 'natGatewayId': self._state.get('natGatewayId', None) }
+        return {"natGatewayId": self._state.get("natGatewayId", None)}
 
     def get_definition_prefix(self):
         return "resources.vpcNatGateways."
 
     def create_after(self, resources, defn):
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.vpc_subnet.VPCSubnetState) or
-                isinstance(r, nixopsaws.resources.elastic_ip.ElasticIPState)}
+        return {
+            r
+            for r in resources
+            if isinstance(r, nixopsaws.resources.vpc_subnet.VPCSubnetState)
+            or isinstance(r, nixopsaws.resources.elastic_ip.ElasticIPState)
+        }
 
     def realize_create_gtw(self, allow_recreate):
         config = self.get_defn()
         if self.state == self.UP:
             if not allow_recreate:
-                raise Exception("nat gateway {} defintion changed"
-                                " use --allow-recreate if you want to create a new one".format(
-                                    self._state['natGatewayId']))
+                raise Exception(
+                    "nat gateway {} defintion changed"
+                    " use --allow-recreate if you want to create a new one".format(
+                        self._state["natGatewayId"]
+                    )
+                )
             self.warn("nat gateway changed, recreating...")
             self._destroy()
 
-        self._state['region'] = config['region']
+        self._state["region"] = config["region"]
 
-        subnet_id = config['subnetId']
-        allocation_id = config['allocationId']
+        subnet_id = config["subnetId"]
+        allocation_id = config["allocationId"]
 
         if allocation_id.startswith("res-"):
-            res = self.depl.get_typed_resource(allocation_id[4:].split(".")[0], "elastic-ip")
+            res = self.depl.get_typed_resource(
+                allocation_id[4:].split(".")[0], "elastic-ip"
+            )
             allocation_id = res.allocation_id
 
         if subnet_id.startswith("res-"):
-            res = self.depl.get_typed_resource(subnet_id[4:].split(".")[0], "vpc-subnet")
-            subnet_id = res._state['subnetId']
+            res = self.depl.get_typed_resource(
+                subnet_id[4:].split(".")[0], "vpc-subnet"
+            )
+            subnet_id = res._state["subnetId"]
 
-        if not self._state.get('creationToken', None):
-            self._state['creationToken'] = str(uuid.uuid4())
+        if not self._state.get("creationToken", None):
+            self._state["creationToken"] = str(uuid.uuid4())
             self.state = self.STARTING
 
-        response = self.get_client().create_nat_gateway(ClientToken=self._state['creationToken'], AllocationId=allocation_id,
-                                                   SubnetId=subnet_id)
+        response = self.get_client().create_nat_gateway(
+            ClientToken=self._state["creationToken"],
+            AllocationId=allocation_id,
+            SubnetId=subnet_id,
+        )
 
-        gtw_id = response['NatGateway']['NatGatewayId']
+        gtw_id = response["NatGateway"]["NatGatewayId"]
         with self.depl._db:
             self.state = self.UP
-            self._state['subnetId'] = subnet_id
-            self._state['allocationId'] = allocation_id
-            self._state['natGatewayId'] = gtw_id
+            self._state["subnetId"] = subnet_id
+            self._state["allocationId"] = allocation_id
+            self._state["natGatewayId"] = gtw_id
 
     def wait_for_nat_gtw_deletion(self):
-        self.log("waiting for nat gateway {0} to be deleted".format(self._state['natGatewayId']))
+        self.log(
+            "waiting for nat gateway {0} to be deleted".format(
+                self._state["natGatewayId"]
+            )
+        )
         while True:
             try:
                 response = self.get_client().describe_nat_gateways(
-                    NatGatewayIds=[self._state['natGatewayId']]
-                    )
+                    NatGatewayIds=[self._state["natGatewayId"]]
+                )
             except botocore.exceptions.ClientError as e:
-                if e.response['Error']['Code'] == "InvalidNatGatewayID.NotFound" or e.response['Error']['Code'] == "NatGatewayNotFound":
-                    self.warn("nat gateway {} was already deleted".format(self._state['natGatewayId']))
+                if (
+                    e.response["Error"]["Code"] == "InvalidNatGatewayID.NotFound"
+                    or e.response["Error"]["Code"] == "NatGatewayNotFound"
+                ):
+                    self.warn(
+                        "nat gateway {} was already deleted".format(
+                            self._state["natGatewayId"]
+                        )
+                    )
                     break
                 else:
                     raise
-            if len(response['NatGateways'])==1:
-                if response['NatGateways'][0]['State'] == "deleted":
+            if len(response["NatGateways"]) == 1:
+                if response["NatGateways"][0]["State"] == "deleted":
                     break
-                elif response['NatGateways'][0]['State'] != "deleting":
-                    raise Exception("nat gateway {0} in an unexpected state {1}".format(
-                        self._state['natGatewayId'], response['NatGateways'][0]['State']))
+                elif response["NatGateways"][0]["State"] != "deleting":
+                    raise Exception(
+                        "nat gateway {0} in an unexpected state {1}".format(
+                            self._state["natGatewayId"],
+                            response["NatGateways"][0]["State"],
+                        )
+                    )
                 self.log_continue(".")
                 time.sleep(1)
             else:
@@ -134,13 +172,23 @@ class VPCNatGatewayState(nixops.resources.DiffEngineResourceState, EC2CommonStat
 
     def _destroy(self):
         if self.state == self.UP:
-            self.log("deleting vpc NAT gateway {}".format(self._state['natGatewayId']))
+            self.log("deleting vpc NAT gateway {}".format(self._state["natGatewayId"]))
             try:
-                self.get_client().delete_nat_gateway(NatGatewayId=self._state['natGatewayId'])
-                with self.depl._db: self.state = self.STOPPING
+                self.get_client().delete_nat_gateway(
+                    NatGatewayId=self._state["natGatewayId"]
+                )
+                with self.depl._db:
+                    self.state = self.STOPPING
             except botocore.exceptions.ClientError as e:
-                if e.response['Error']['Code'] == "InvalidNatGatewayID.NotFound" or e.response['Error']['Code'] == "NatGatewayNotFound":
-                    self.warn("nat gateway {} was already deleted".format(self._state['natGatewayId']))
+                if (
+                    e.response["Error"]["Code"] == "InvalidNatGatewayID.NotFound"
+                    or e.response["Error"]["Code"] == "NatGatewayNotFound"
+                ):
+                    self.warn(
+                        "nat gateway {} was already deleted".format(
+                            self._state["natGatewayId"]
+                        )
+                    )
                 else:
                     raise e
 
@@ -149,10 +197,10 @@ class VPCNatGatewayState(nixops.resources.DiffEngineResourceState, EC2CommonStat
 
         with self.depl._db:
             self.state = self.MISSING
-            self._state['region'] = None
-            self._state['subnetId'] = None
-            self._state['allocationId'] = None
-            self._state['natGatewayId'] = None
+            self._state["region"] = None
+            self._state["subnetId"] = None
+            self._state["allocationId"] = None
+            self._state["natGatewayId"] = None
 
     def destroy(self, wipe=False):
         self._destroy()

--- a/nixopsaws/resources/vpc_network_acl.py
+++ b/nixopsaws/resources/vpc_network_acl.py
@@ -11,6 +11,7 @@ import nixopsaws.ec2_utils
 from nixops.diff import Diff, Handler
 from nixops.state import StateDict
 
+
 class VPCNetworkAcldefinition(nixops.resources.ResourceDefinition):
     """definition of a vpc network ACL."""
 
@@ -29,9 +30,11 @@ class VPCNetworkAcldefinition(nixops.resources.ResourceDefinition):
 class VPCNetworkAclstate(nixops.resources.DiffEngineResourceState, EC2CommonState):
     """state of a vpc Network ACL."""
 
-    state = nixops.util.attr_property("state", nixops.resources.DiffEngineResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.DiffEngineResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("accessKeyId", None)
-    _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ['networkAclId']
+    _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ["networkAclId"]
 
     @classmethod
     def get_type(cls):
@@ -40,17 +43,30 @@ class VPCNetworkAclstate(nixops.resources.DiffEngineResourceState, EC2CommonStat
     def __init__(self, depl, name, id):
         nixops.resources.DiffEngineResourceState.__init__(self, depl, name, id)
         self._state = StateDict(depl, id)
-        self.network_acl_id = self._state.get('networkAclId', None)
-        self.handle_create_network_acl = Handler(['region', 'vpcId'], handle=self.realize_create_network_acl)
-        self.handle_entries = Handler(['entries'], after=[self.handle_create_network_acl]
-                                      , handle=self.realize_entries_change)
-        self.handle_subnet_association = Handler(['subnetIds'], after=[self.handle_create_network_acl]
-                                                 , handle=self.realize_subnets_change)
-        self.handle_tag_update = Handler(['tags'], after=[self.handle_create_network_acl], handle=self.realize_update_tag)
+        self.network_acl_id = self._state.get("networkAclId", None)
+        self.handle_create_network_acl = Handler(
+            ["region", "vpcId"], handle=self.realize_create_network_acl
+        )
+        self.handle_entries = Handler(
+            ["entries"],
+            after=[self.handle_create_network_acl],
+            handle=self.realize_entries_change,
+        )
+        self.handle_subnet_association = Handler(
+            ["subnetIds"],
+            after=[self.handle_create_network_acl],
+            handle=self.realize_subnets_change,
+        )
+        self.handle_tag_update = Handler(
+            ["tags"],
+            after=[self.handle_create_network_acl],
+            handle=self.realize_update_tag,
+        )
 
     def show_type(self):
         s = super(VPCNetworkAclstate, self).show_type()
-        if self._state.get('region', None): s = "{0} [{1}]".format(s, self._state['region'])
+        if self._state.get("region", None):
+            s = "{0} [{1}]".format(s, self._state["region"])
         return s
 
     @property
@@ -58,54 +74,69 @@ class VPCNetworkAclstate(nixops.resources.DiffEngineResourceState, EC2CommonStat
         return self.network_acl_id
 
     def prefix_definition(self, attr):
-        return {('resources', 'vpcNetworkAcls'): attr}
+        return {("resources", "vpcNetworkAcls"): attr}
 
     def get_definition_prefix(self):
         return "resources.vpcNetworkAcls."
 
     def create_after(self, resources, defn):
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.vpc.VPCState) or
-                isinstance(r, nixopsaws.resources.vpc_subnet.VPCSubnetState)}
+        return {
+            r
+            for r in resources
+            if isinstance(r, nixopsaws.resources.vpc.VPCState)
+            or isinstance(r, nixopsaws.resources.vpc_subnet.VPCSubnetState)
+        }
 
     def realize_create_network_acl(self, allow_recreate):
         config = self.get_defn()
         if self.state == self.UP:
             if not allow_recreate:
-                raise Exception("network ACL {} definition changed and it needs to be recreated"
-                                " use --allow-recreate if you want to create a new one".format(self.network_acl_id))
+                raise Exception(
+                    "network ACL {} definition changed and it needs to be recreated"
+                    " use --allow-recreate if you want to create a new one".format(
+                        self.network_acl_id
+                    )
+                )
             self.warn("network ACL definition changed, recreating ...")
             self._destroy()
 
-        self._state['region'] = config['region']
+        self._state["region"] = config["region"]
 
-        vpc_id = config['vpcId']
+        vpc_id = config["vpcId"]
 
         if vpc_id.startswith("res-"):
             res = self.depl.get_typed_resource(vpc_id[4:].split(".")[0], "vpc")
-            vpc_id = res._state['vpcId']
+            vpc_id = res._state["vpcId"]
 
         self.log("creating network ACL in vpc {}".format(vpc_id))
         response = self.get_client().create_network_acl(VpcId=vpc_id)
-        self.network_acl_id = response['NetworkAcl']['NetworkAclId']
+        self.network_acl_id = response["NetworkAcl"]["NetworkAclId"]
 
         with self.depl._db:
             self.state = self.UP
-            self._state['vpcId'] = vpc_id
-            self._state['networkAclId'] = self.network_acl_id
+            self._state["vpcId"] = vpc_id
+            self._state["networkAclId"] = self.network_acl_id
 
     def realize_entries_change(self, allow_recreate):
         config = self.get_defn()
-        old_entries = self._state.get('entries', [])
-        new_entries = config['entries']
+        old_entries = self._state.get("entries", [])
+        new_entries = config["entries"]
         to_remove = [e for e in old_entries if e not in new_entries]
         to_create = [e for e in new_entries if e not in old_entries]
         for entry in to_remove:
             try:
-                self.get_client().delete_network_acl_entry(NetworkAclId=self.network_acl_id, RuleNumber=entry['ruleNumber'], Egress=entry['egress'])
+                self.get_client().delete_network_acl_entry(
+                    NetworkAclId=self.network_acl_id,
+                    RuleNumber=entry["ruleNumber"],
+                    Egress=entry["egress"],
+                )
             except botocore.exceptions.ClientError as e:
-                if e.response['Error']['Code'] == "InvalidNetworkAclEntry.NotFound":
-                    self.warn("rule {0} was already deleted from network ACL {1}".format(entry['ruleNumber'], self.network_acl_id))
+                if e.response["Error"]["Code"] == "InvalidNetworkAclEntry.NotFound":
+                    self.warn(
+                        "rule {0} was already deleted from network ACL {1}".format(
+                            entry["ruleNumber"], self.network_acl_id
+                        )
+                    )
                 else:
                     raise e
 
@@ -113,24 +144,24 @@ class VPCNetworkAclstate(nixops.resources.DiffEngineResourceState, EC2CommonStat
             rule = self.process_rule_entry(entry)
             self.get_client().create_network_acl_entry(**rule)
         with self.depl._db:
-            self._state['entries'] = config['entries']
+            self._state["entries"] = config["entries"]
 
     def realize_subnets_change(self, allow_recreate):
         config = self.get_defn()
-        old_subnets = self._state.get('subnetIds', [])
+        old_subnets = self._state.get("subnetIds", [])
         new_subnets = []
-        for s in config['subnetIds']:
+        for s in config["subnetIds"]:
             if s.startswith("res-"):
                 res = self.depl.get_typed_resource(s[4:].split(".")[0], "vpc-subnet")
-                new_subnets.append(res._state['subnetId'])
+                new_subnets.append(res._state["subnetId"])
             else:
                 new_subnets.append(s)
 
-        vpc_id = config['vpcId']
+        vpc_id = config["vpcId"]
 
         if vpc_id.startswith("res-"):
             res = self.depl.get_typed_resource(vpc_id[4:].split(".")[0], "vpc")
-            vpc_id = res._state['vpcId']
+            vpc_id = res._state["vpcId"]
 
         subnets_to_remove = [s for s in old_subnets if s not in new_subnets]
         subnets_to_add = [s for s in new_subnets if s not in old_subnets]
@@ -139,72 +170,107 @@ class VPCNetworkAclstate(nixops.resources.DiffEngineResourceState, EC2CommonStat
 
         for subnet in subnets_to_remove:
             association_id = self.get_network_acl_association(subnet)
-            self.log("associating subnet {0} to default network acl {1}".format(subnet, default_network_acl))
-            self.get_client().replace_network_acl_association(AssociationId=association_id, NetworkAclId=default_network_acl)
+            self.log(
+                "associating subnet {0} to default network acl {1}".format(
+                    subnet, default_network_acl
+                )
+            )
+            self.get_client().replace_network_acl_association(
+                AssociationId=association_id, NetworkAclId=default_network_acl
+            )
 
         for subnet in subnets_to_add:
             association_id = self.get_network_acl_association(subnet)
-            self.log("associating subnet {0} to network acl {1}".format(subnet, self.network_acl_id))
-            self.get_client().replace_network_acl_association(AssociationId=association_id, NetworkAclId=self.network_acl_id)
+            self.log(
+                "associating subnet {0} to network acl {1}".format(
+                    subnet, self.network_acl_id
+                )
+            )
+            self.get_client().replace_network_acl_association(
+                AssociationId=association_id, NetworkAclId=self.network_acl_id
+            )
 
         with self.depl._db:
-            self._state['subnetIds'] = new_subnets
+            self._state["subnetIds"] = new_subnets
 
     def get_default_network_acl(self, vpc_id):
-        response = self.get_client().describe_network_acls(Filters=[{ "Name": "default", "Values": [ "true" ] },
-             { "Name": "vpc-id", "Values": [ vpc_id ]}])
-        return response['NetworkAcls'][0]['NetworkAclId']
+        response = self.get_client().describe_network_acls(
+            Filters=[
+                {"Name": "default", "Values": ["true"]},
+                {"Name": "vpc-id", "Values": [vpc_id]},
+            ]
+        )
+        return response["NetworkAcls"][0]["NetworkAclId"]
 
     def get_network_acl_association(self, subnet_id):
-        response = self.get_client().describe_network_acls(Filters=[{"Name": "association.subnet-id", "Values":[ subnet_id ]}])
-        for association in  response['NetworkAcls'][0]['Associations']:
-            if association['SubnetId'] == subnet_id:
-                return association['NetworkAclAssociationId']
+        response = self.get_client().describe_network_acls(
+            Filters=[{"Name": "association.subnet-id", "Values": [subnet_id]}]
+        )
+        for association in response["NetworkAcls"][0]["Associations"]:
+            if association["SubnetId"] == subnet_id:
+                return association["NetworkAclAssociationId"]
 
     def process_rule_entry(self, entry):
         rule = dict()
-        rule['NetworkAclId'] = self.network_acl_id
-        rule['Protocol'] = entry['protocol']
-        rule['RuleNumber'] = entry['ruleNumber']
-        rule['RuleAction'] = entry['ruleAction']
-        rule['Egress'] = entry['egress']
-        if entry['cidrBlock'] is not None: rule['CidrBlock'] = entry['cidrBlock']
-        if entry['ipv6CidrBlock'] is not None: rule['Ipv6CidrBlock'] = entry['ipv6CidrBlock']
-        if entry['icmpCode'] and entry['icmpType']:
-            rule['IcmpTypeCode'] = {"Type": entry['icmpType'], "Code": entry['icmpCode']}
-        if entry['fromPort'] and entry['toPort']:
-            rule['PortRange'] = { "From": entry['fromPort'], "To": entry['toPort'] }
+        rule["NetworkAclId"] = self.network_acl_id
+        rule["Protocol"] = entry["protocol"]
+        rule["RuleNumber"] = entry["ruleNumber"]
+        rule["RuleAction"] = entry["ruleAction"]
+        rule["Egress"] = entry["egress"]
+        if entry["cidrBlock"] is not None:
+            rule["CidrBlock"] = entry["cidrBlock"]
+        if entry["ipv6CidrBlock"] is not None:
+            rule["Ipv6CidrBlock"] = entry["ipv6CidrBlock"]
+        if entry["icmpCode"] and entry["icmpType"]:
+            rule["IcmpTypeCode"] = {
+                "Type": entry["icmpType"],
+                "Code": entry["icmpCode"],
+            }
+        if entry["fromPort"] and entry["toPort"]:
+            rule["PortRange"] = {"From": entry["fromPort"], "To": entry["toPort"]}
         return rule
 
     def _destroy(self):
-        if self.state != self.UP: return
+        if self.state != self.UP:
+            return
         try:
-            subnets = self._state.get('subnetIds', [])
-            default_network_acl = self.get_default_network_acl(self._state['vpcId'])
+            subnets = self._state.get("subnetIds", [])
+            default_network_acl = self.get_default_network_acl(self._state["vpcId"])
             for subnet in subnets:
                 association_id = self.get_network_acl_association(subnet)
-                self.log("associating subnet {0} to default network acl {1}".format(subnet, default_network_acl))
-                self.get_client().replace_network_acl_association(AssociationId=association_id, NetworkAclId=default_network_acl)
+                self.log(
+                    "associating subnet {0} to default network acl {1}".format(
+                        subnet, default_network_acl
+                    )
+                )
+                self.get_client().replace_network_acl_association(
+                    AssociationId=association_id, NetworkAclId=default_network_acl
+                )
             self.log("deleting network acl {}".format(self.network_acl_id))
             self.get_client().delete_network_acl(NetworkAclId=self.network_acl_id)
         except botocore.exceptions.ClientError as e:
-            if e.response['Error']['Code'] == 'InvalidNetworkAclID.NotFound':
-                self.warn("network ACL {} was already deleted".format(self.network_acl_id))
+            if e.response["Error"]["Code"] == "InvalidNetworkAclID.NotFound":
+                self.warn(
+                    "network ACL {} was already deleted".format(self.network_acl_id)
+                )
             else:
                 raise e
 
         with self.depl._db:
             self.state = self.MISSING
-            self._state['networkAclId'] = None
-            self._state['region'] = None
-            self._state['vpcId'] = None
-            self._state['entries'] = None
+            self._state["networkAclId"] = None
+            self._state["region"] = None
+            self._state["vpcId"] = None
+            self._state["entries"] = None
 
     def realize_update_tag(self, allow_recreate):
         config = self.get_defn()
-        tags = config['tags']
+        tags = config["tags"]
         tags.update(self.get_common_tags())
-        self.get_client().create_tags(Resources=[self._state['networkAclId']], Tags=[{"Key": k, "Value": tags[k]} for k in tags])
+        self.get_client().create_tags(
+            Resources=[self._state["networkAclId"]],
+            Tags=[{"Key": k, "Value": tags[k]} for k in tags],
+        )
 
     def destroy(self, wipe=False):
         self._destroy()

--- a/nixopsaws/resources/vpc_network_interface.py
+++ b/nixopsaws/resources/vpc_network_interface.py
@@ -12,6 +12,7 @@ import nixopsaws.ec2_utils
 from nixops.diff import Diff, Handler
 from nixops.state import StateDict
 
+
 class VPCNetworkInterfaceDefinition(nixops.resources.ResourceDefinition):
     """Definition of a VPC network interface"""
 
@@ -26,12 +27,17 @@ class VPCNetworkInterfaceDefinition(nixops.resources.ResourceDefinition):
     def show_type(self):
         return "{0}".format(self.get_type())
 
-class VPCNetworkInterfaceState(nixops.resources.DiffEngineResourceState, EC2CommonState):
+
+class VPCNetworkInterfaceState(
+    nixops.resources.DiffEngineResourceState, EC2CommonState
+):
     """State of a VPC network interface"""
 
-    state = nixops.util.attr_property("state", nixops.resources.DiffEngineResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.DiffEngineResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("accessKeyId", None)
-    _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ['networkInterfaceId']
+    _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ["networkInterfaceId"]
 
     @classmethod
     def get_type(cls):
@@ -40,121 +46,154 @@ class VPCNetworkInterfaceState(nixops.resources.DiffEngineResourceState, EC2Comm
     def __init__(self, depl, name, id):
         nixops.resources.DiffEngineResourceState.__init__(self, depl, name, id)
         self._state = StateDict(depl, id)
-        self.region = self._state.get('region', None)
-        self.handle_create_eni = Handler(['region', 'subnetId', 'primaryPrivateIpAddress',
-                                          'privateIpAddresses', 'secondaryPrivateIpAddressCount'],
-                                          handle=self.realize_create_eni)
-        self.handle_modify_eni_attrs = Handler(['description', 'securityGroups', 'sourceDestCheck'],
-                                               handle=self.realize_modify_eni_attrs,
-                                               after=[self.handle_create_eni])
-        self.handle_tag_update = Handler(['tags'], after=[self.handle_create_eni], handle=self.realize_update_tag)
+        self.region = self._state.get("region", None)
+        self.handle_create_eni = Handler(
+            [
+                "region",
+                "subnetId",
+                "primaryPrivateIpAddress",
+                "privateIpAddresses",
+                "secondaryPrivateIpAddressCount",
+            ],
+            handle=self.realize_create_eni,
+        )
+        self.handle_modify_eni_attrs = Handler(
+            ["description", "securityGroups", "sourceDestCheck"],
+            handle=self.realize_modify_eni_attrs,
+            after=[self.handle_create_eni],
+        )
+        self.handle_tag_update = Handler(
+            ["tags"], after=[self.handle_create_eni], handle=self.realize_update_tag
+        )
 
     def show_type(self):
         s = super(VPCNetworkInterfaceState, self).show_type()
-        if self.region: s = "{0} [{1}]".format(s, self.region)
+        if self.region:
+            s = "{0} [{1}]".format(s, self.region)
         return s
 
     @property
     def resource_id(self):
-        return self._state.get('networkInterfaceId', None)
+        return self._state.get("networkInterfaceId", None)
 
     def prefix_definition(self, attr):
-        return {('resources', 'vpcNetworkInterfaces'): attr}
+        return {("resources", "vpcNetworkInterfaces"): attr}
 
     def get_physical_spec(self):
-        return { 'networkInterfaceId': self._state.get('networkInterfaceId', None) }
+        return {"networkInterfaceId": self._state.get("networkInterfaceId", None)}
 
     def get_definition_prefix(self):
         return "resources.vpcNetworkInterfaces."
 
     def create_after(self, resources, defn):
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.vpc_subnet.VPCSubnetState)}
+        return {
+            r
+            for r in resources
+            if isinstance(r, nixopsaws.resources.vpc_subnet.VPCSubnetState)
+        }
 
     def realize_create_eni(self, allow_recreate):
         config = self.get_defn()
         if self.state == self.UP:
             if not allow_recreate:
-                raise Exception("network interface {} definition changed and it needs to be recreated"
-                                " use --allow-recreate if you want to create a new one".format(self._state['networkInterfaceId']))
+                raise Exception(
+                    "network interface {} definition changed and it needs to be recreated"
+                    " use --allow-recreate if you want to create a new one".format(
+                        self._state["networkInterfaceId"]
+                    )
+                )
             self.warn("network interface definition changed, recreating ...")
             self._destroy()
 
-        self._state['region'] = config['region']
+        self._state["region"] = config["region"]
 
         eni_input = self.network_interface_input(config)
-        self.log("creating vpc network interface under {}".format(eni_input['SubnetId']))
+        self.log(
+            "creating vpc network interface under {}".format(eni_input["SubnetId"])
+        )
         response = self.get_client().create_network_interface(**eni_input)
 
-        eni = response['NetworkInterface']
+        eni = response["NetworkInterface"]
 
         def split_ips(eni_ips):
             seconday = []
             for ip in eni_ips:
-                if ip['Primary']:
-                    primary = ip['PrivateIpAddress']
+                if ip["Primary"]:
+                    primary = ip["PrivateIpAddress"]
                 else:
-                    seconday.append(ip['PrivateIpAddress'])
+                    seconday.append(ip["PrivateIpAddress"])
             return primary, seconday
 
-        primary, secondary = split_ips(eni['PrivateIpAddresses'])
+        primary, secondary = split_ips(eni["PrivateIpAddresses"])
 
         with self.depl._db:
             self.state = self.UP
-            self._state['subnetId'] = eni_input['SubnetId']
-            self._state['networkInterfaceId'] = eni['NetworkInterfaceId']
-            self._state['primaryPrivateIpAddress'] = primary
-            self._state['privateIpAddresses'] = secondary
-            self._state['secondaryPrivateIpAddressCount'] = config['secondaryPrivateIpAddressCount']
+            self._state["subnetId"] = eni_input["SubnetId"]
+            self._state["networkInterfaceId"] = eni["NetworkInterfaceId"]
+            self._state["primaryPrivateIpAddress"] = primary
+            self._state["privateIpAddresses"] = secondary
+            self._state["secondaryPrivateIpAddressCount"] = config[
+                "secondaryPrivateIpAddressCount"
+            ]
 
     def network_interface_input(self, config):
-        subnet_id = config['subnetId']
+        subnet_id = config["subnetId"]
         if subnet_id.startswith("res-"):
-            res = self.depl.get_typed_resource(subnet_id[4:].split(".")[0], "vpc-subnet")
-            subnet_id = res._state['subnetId']
+            res = self.depl.get_typed_resource(
+                subnet_id[4:].split(".")[0], "vpc-subnet"
+            )
+            subnet_id = res._state["subnetId"]
 
         groups = []
-        for grp in config['securityGroups']:
+        for grp in config["securityGroups"]:
             if grp.startswith("res-"):
-                res = self.depl.get_typed_resource(grp[4:].split(".")[0], "ec2-security-group")
+                res = self.depl.get_typed_resource(
+                    grp[4:].split(".")[0], "ec2-security-group"
+                )
                 assert res.vpc_id
                 groups.append(res.security_group_id)
             else:
                 groups.append(grp)
 
-        primary_ip = config['primaryPrivateIpAddress']
-        secondary_private_ips = config['privateIpAddresses']
-        secondary_ip_count = config['secondaryPrivateIpAddressCount']
+        primary_ip = config["primaryPrivateIpAddress"]
+        secondary_private_ips = config["privateIpAddresses"]
+        secondary_ip_count = config["secondaryPrivateIpAddressCount"]
         if (primary_ip and len(secondary_private_ips) > 0) and secondary_ip_count:
-            raise Exception("you can't set privateIpAddresses/primaryPrivateIpAddress options together"
-                            " with secondaryPrivateIpAddressCount")
+            raise Exception(
+                "you can't set privateIpAddresses/primaryPrivateIpAddress options together"
+                " with secondaryPrivateIpAddressCount"
+            )
         ips = []
         if primary_ip:
-            ips.append({'Primary':True, 'PrivateIpAddress':primary_ip})
+            ips.append({"Primary": True, "PrivateIpAddress": primary_ip})
         if len(secondary_private_ips) > 0:
             for ip in secondary_private_ips:
-                ips.append({'Primary':False, 'PrivateIpAddress':ip})
+                ips.append({"Primary": False, "PrivateIpAddress": ip})
 
         cfg = dict()
-        cfg['Description'] = config['description']
-        cfg['Groups'] = groups
-        cfg['SubnetId'] = subnet_id
+        cfg["Description"] = config["description"]
+        cfg["Groups"] = groups
+        cfg["SubnetId"] = subnet_id
         if not secondary_ip_count:
-            cfg['PrivateIpAddresses'] = ips
+            cfg["PrivateIpAddresses"] = ips
         else:
-            cfg['secondaryPrivateIpAddressCount'] = secondary_ip_count
+            cfg["secondaryPrivateIpAddressCount"] = secondary_ip_count
 
         return cfg
 
     def realize_modify_eni_attrs(self, allow_recreate):
         config = self.get_defn()
         self.log("applying network interface attribute changes")
-        self.get_client().modify_network_interface_attribute(NetworkInterfaceId=self._state['networkInterfaceId'],
-                                                        Description={'Value':config['description']})
+        self.get_client().modify_network_interface_attribute(
+            NetworkInterfaceId=self._state["networkInterfaceId"],
+            Description={"Value": config["description"]},
+        )
         groups = []
-        for grp in config['securityGroups']:
+        for grp in config["securityGroups"]:
             if grp.startswith("res-"):
-                res = self.depl.get_typed_resource(grp[4:].split(".")[0], "ec2-security-group")
+                res = self.depl.get_typed_resource(
+                    grp[4:].split(".")[0], "ec2-security-group"
+                )
                 assert res.vpc_id
                 groups.append(res.security_group_id)
             else:
@@ -162,41 +201,55 @@ class VPCNetworkInterfaceState(nixops.resources.DiffEngineResourceState, EC2Comm
 
         if len(groups) >= 1:
             self.get_client().modify_network_interface_attribute(
-                NetworkInterfaceId=self._state['networkInterfaceId'],
-                Groups=groups)
+                NetworkInterfaceId=self._state["networkInterfaceId"], Groups=groups
+            )
 
-        self.get_client().modify_network_interface_attribute(NetworkInterfaceId=self._state['networkInterfaceId'],
-                                                        SourceDestCheck={
-                                                            'Value':config['sourceDestCheck']
-                                                            })
+        self.get_client().modify_network_interface_attribute(
+            NetworkInterfaceId=self._state["networkInterfaceId"],
+            SourceDestCheck={"Value": config["sourceDestCheck"]},
+        )
         with self.depl._db:
-            self._state['description'] = config['description']
-            self._state['securityGroups'] = groups
-            self._state['sourceDestCheck'] = config['sourceDestCheck']
+            self._state["description"] = config["description"]
+            self._state["securityGroups"] = groups
+            self._state["sourceDestCheck"] = config["sourceDestCheck"]
 
     def realize_update_tag(self, allow_recreate):
         config = self.get_defn()
-        tags = config['tags']
+        tags = config["tags"]
         tags.update(self.get_common_tags())
-        self.get_client().create_tags(Resources=[self._state['networkInterfaceId']], Tags=[{"Key": k, "Value": tags[k]} for k in tags])
+        self.get_client().create_tags(
+            Resources=[self._state["networkInterfaceId"]],
+            Tags=[{"Key": k, "Value": tags[k]} for k in tags],
+        )
 
     def _destroy(self):
-        if self.state != self.UP: return
-        self.log("deleting vpc network interface {}".format(self._state['networkInterfaceId']))
+        if self.state != self.UP:
+            return
+        self.log(
+            "deleting vpc network interface {}".format(
+                self._state["networkInterfaceId"]
+            )
+        )
         try:
-            self.get_client().delete_network_interface(NetworkInterfaceId=self._state['networkInterfaceId'])
+            self.get_client().delete_network_interface(
+                NetworkInterfaceId=self._state["networkInterfaceId"]
+            )
         except botocore.exceptions.ClientError as e:
-            if e.response['Error']['Code'] == "InvalidNetworkInterfaceID.NotFound":
-                self.warn("network interface {} was already deleted".format(self._state['networkInterfaceId']))
+            if e.response["Error"]["Code"] == "InvalidNetworkInterfaceID.NotFound":
+                self.warn(
+                    "network interface {} was already deleted".format(
+                        self._state["networkInterfaceId"]
+                    )
+                )
             else:
                 raise e
 
         with self.depl._db:
             self.state = self.MISSING
-            self._state['networkInterfaceId'] = None
-            self._state['primaryPrivateIpAddress'] = None
-            self._state['privateIpAddresses'] = None
-            self._state['secondaryPrivateIpAddressCount'] = None
+            self._state["networkInterfaceId"] = None
+            self._state["primaryPrivateIpAddress"] = None
+            self._state["privateIpAddresses"] = None
+            self._state["secondaryPrivateIpAddressCount"] = None
 
     def destroy(self, wipe=False):
         self._destroy()

--- a/nixopsaws/resources/vpc_network_interface_attachment.py
+++ b/nixopsaws/resources/vpc_network_interface_attachment.py
@@ -14,6 +14,7 @@ import nixopsaws.ec2_utils
 from nixops.diff import Diff, Handler
 from nixops.state import StateDict
 
+
 class VPCNetworkInterfaceAttachmentDefinition(nixops.resources.ResourceDefinition):
     """Definition of a VPC network interface attachment"""
 
@@ -28,12 +29,17 @@ class VPCNetworkInterfaceAttachmentDefinition(nixops.resources.ResourceDefinitio
     def show_type(self):
         return "{0}".format(self.get_type())
 
-class VPCNetworkInterfaceAttachmentState(nixops.resources.DiffEngineResourceState, EC2CommonState):
+
+class VPCNetworkInterfaceAttachmentState(
+    nixops.resources.DiffEngineResourceState, EC2CommonState
+):
     """State of a VPC network interface attachment"""
 
-    state = nixops.util.attr_property("state", nixops.resources.DiffEngineResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.DiffEngineResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("accessKeyId", None)
-    _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ['attachmentId']
+    _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ["attachmentId"]
 
     @classmethod
     def get_type(cls):
@@ -42,51 +48,62 @@ class VPCNetworkInterfaceAttachmentState(nixops.resources.DiffEngineResourceStat
     def __init__(self, depl, name, id):
         nixops.resources.DiffEngineResourceState.__init__(self, depl, name, id)
         self._state = StateDict(depl, id)
-        self.region = self._state.get('region', None)
-        self.handle_create_eni_attachment = Handler(['region', 'networkInterfaceId', 'instanceId', 'deviceIndex' ],
-                                          handle=self.realize_create_eni_attachment)
+        self.region = self._state.get("region", None)
+        self.handle_create_eni_attachment = Handler(
+            ["region", "networkInterfaceId", "instanceId", "deviceIndex"],
+            handle=self.realize_create_eni_attachment,
+        )
 
     def show_type(self):
         s = super(VPCNetworkInterfaceAttachmentState, self).show_type()
-        if self.region: s = "{0} [{1}]".format(s, self.region)
+        if self.region:
+            s = "{0} [{1}]".format(s, self.region)
         return s
 
     @property
     def resource_id(self):
-        return self._state.get('attachmentId', None)
+        return self._state.get("attachmentId", None)
 
     def prefix_definition(self, attr):
-        return {('resources', 'vpcNetworkInterfaceAttachments'): attr}
+        return {("resources", "vpcNetworkInterfaceAttachments"): attr}
 
     def get_physical_spec(self):
-        return { 'attachmentId': self._state.get('attachmentId', None) }
+        return {"attachmentId": self._state.get("attachmentId", None)}
 
     def get_definition_prefix(self):
         return "resources.vpcNetworkInterfaceAttachments."
 
     def create_after(self, resources, defn):
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.vpc_network_interface.VPCNetworkInterfaceState) or
-                isinstance(r, nixopsaws.backends.ec2.EC2State)}
+        return {
+            r
+            for r in resources
+            if isinstance(
+                r, nixopsaws.resources.vpc_network_interface.VPCNetworkInterfaceState
+            )
+            or isinstance(r, nixopsaws.backends.ec2.EC2State)
+        }
 
     def ensure_state_up(self):
         config = self.get_defn()
         self._state["region"] = config["region"]
-        if self._state.get('attachmentId', None):
+        if self._state.get("attachmentId", None):
             if self.state != self.UP:
-                self.wait_for_eni_attachment(self._state['networkInterfaceId'])
+                self.wait_for_eni_attachment(self._state["networkInterfaceId"])
 
     def wait_for_eni_attachment(self, eni_id):
         while True:
             response = self.get_client().describe_network_interface_attribute(
-                Attribute='attachment',
-                NetworkInterfaceId=eni_id)
-            if response.get('Attachment', None):
-                if response['Attachment']['Status'] == 'attached':
+                Attribute="attachment", NetworkInterfaceId=eni_id
+            )
+            if response.get("Attachment", None):
+                if response["Attachment"]["Status"] == "attached":
                     break
-                elif response['Attachment']['Status'] != "attaching":
-                    raise Exception("eni attachment {0} in an unexpected state {1}".format(
-                        eni_id, response['Attachment']['Status']))
+                elif response["Attachment"]["Status"] != "attaching":
+                    raise Exception(
+                        "eni attachment {0} in an unexpected state {1}".format(
+                            eni_id, response["Attachment"]["Status"]
+                        )
+                    )
                 self.log_continue(".")
                 time.sleep(1)
             else:
@@ -101,49 +118,66 @@ class VPCNetworkInterfaceAttachmentState(nixops.resources.DiffEngineResourceStat
         config = self.get_defn()
         if self.state == self.UP:
             if not allow_recreate:
-                raise Exception("network interface attachment {} definition changed and it needs to be recreated"
-                                " use --allow-recreate if you want to create a new one".format(self._state['attachmentId']))
+                raise Exception(
+                    "network interface attachment {} definition changed and it needs to be recreated"
+                    " use --allow-recreate if you want to create a new one".format(
+                        self._state["attachmentId"]
+                    )
+                )
             self.warn("network interface attachment definition changed, recreating ...")
             self._destroy()
 
-        self._state['region'] = config['region']
-        vm_id = config['instanceId']
+        self._state["region"] = config["region"]
+        vm_id = config["instanceId"]
         if vm_id.startswith("res-"):
             res = self.depl.get_typed_resource(vm_id[4:].split(".")[0], "ec2")
             vm_id = res.vm_id
 
-        eni_id = config['networkInterfaceId']
+        eni_id = config["networkInterfaceId"]
         if eni_id.startswith("res-"):
-            res = self.depl.get_typed_resource(eni_id[4:].split(".")[0], "vpc-network-interface")
-            eni_id = res._state['networkInterfaceId']
+            res = self.depl.get_typed_resource(
+                eni_id[4:].split(".")[0], "vpc-network-interface"
+            )
+            eni_id = res._state["networkInterfaceId"]
 
-        self.log("attaching network interface {0} to instance {1}".format(eni_id, vm_id))
+        self.log(
+            "attaching network interface {0} to instance {1}".format(eni_id, vm_id)
+        )
         eni_attachment = self.get_client().attach_network_interface(
-            DeviceIndex=config['deviceIndex'],
+            DeviceIndex=config["deviceIndex"],
             InstanceId=vm_id,
-            NetworkInterfaceId=eni_id)
+            NetworkInterfaceId=eni_id,
+        )
 
         with self.depl._db:
             self.state = self.STARTING
-            self._state['attachmentId'] = eni_attachment['AttachmentId']
-            self._state['instanceId'] = vm_id
-            self._state['deviceIndex'] = config['deviceIndex']
-            self._state['networkInterfaceId'] = eni_id
+            self._state["attachmentId"] = eni_attachment["AttachmentId"]
+            self._state["instanceId"] = vm_id
+            self._state["deviceIndex"] = config["deviceIndex"]
+            self._state["networkInterfaceId"] = eni_id
 
         self.wait_for_eni_attachment(eni_id)
 
     def wait_for_eni_detachment(self):
-        self.log("waiting for eni attachment {0} to be detached from {1}".format(self._state['attachmentId'], self._state["instanceId"]))
+        self.log(
+            "waiting for eni attachment {0} to be detached from {1}".format(
+                self._state["attachmentId"], self._state["instanceId"]
+            )
+        )
         while True:
             response = self.get_client().describe_network_interface_attribute(
-                Attribute='attachment',
-                NetworkInterfaceId=self._state['networkInterfaceId'])
-            if response.get('Attachment', None):
-                if response['Attachment']['Status'] == 'detached':
+                Attribute="attachment",
+                NetworkInterfaceId=self._state["networkInterfaceId"],
+            )
+            if response.get("Attachment", None):
+                if response["Attachment"]["Status"] == "detached":
                     break
-                elif response['Attachment']['Status'] != "detaching":
-                    raise Exception("eni attachment {0} in an unexpected state {1}".format(
-                        eni_id, response['Attachment']['Status']))
+                elif response["Attachment"]["Status"] != "detaching":
+                    raise Exception(
+                        "eni attachment {0} in an unexpected state {1}".format(
+                            eni_id, response["Attachment"]["Status"]
+                        )
+                    )
                 self.log_continue(".")
                 time.sleep(1)
             else:
@@ -153,16 +187,25 @@ class VPCNetworkInterfaceAttachmentState(nixops.resources.DiffEngineResourceStat
 
     def _destroy(self):
         if self.state == self.UP:
-            self.log("detaching vpc network interface attachment {}".format(self._state['attachmentId']))
+            self.log(
+                "detaching vpc network interface attachment {}".format(
+                    self._state["attachmentId"]
+                )
+            )
             try:
-                self.get_client().detach_network_interface(AttachmentId=self._state['attachmentId'],
-                                                      Force=True)
+                self.get_client().detach_network_interface(
+                    AttachmentId=self._state["attachmentId"], Force=True
+                )
                 with self.depl._db:
                     self.state = self.STOPPING
 
             except botocore.exceptions.ClientError as e:
-                if e.response['Error']['Code'] == "InvalidAttachmentID.NotFound":
-                    self.warn("network interface attachment {} was already detached".format(self._state['attachmentId']))
+                if e.response["Error"]["Code"] == "InvalidAttachmentID.NotFound":
+                    self.warn(
+                        "network interface attachment {} was already detached".format(
+                            self._state["attachmentId"]
+                        )
+                    )
                 else:
                     raise e
         if self.state == self.STOPPING:
@@ -170,11 +213,11 @@ class VPCNetworkInterfaceAttachmentState(nixops.resources.DiffEngineResourceStat
 
         with self.depl._db:
             self.state = self.MISSING
-            self._state['region'] = None
-            self._state['attachmentId'] = None
-            self._state['instanceId'] = None
-            self._state['deviceIndex'] = None
-            self._state['networkInterfaceId'] = None
+            self._state["region"] = None
+            self._state["attachmentId"] = None
+            self._state["instanceId"] = None
+            self._state["deviceIndex"] = None
+            self._state["networkInterfaceId"] = None
 
     def destroy(self, wipe=False):
         self._destroy()

--- a/nixopsaws/resources/vpc_route.py
+++ b/nixopsaws/resources/vpc_route.py
@@ -12,6 +12,7 @@ import nixopsaws.ec2_utils
 from nixops.diff import Diff, Handler
 from nixops.state import StateDict
 
+
 class VPCRouteDefinition(nixops.resources.ResourceDefinition):
     """Definition of a VPC route"""
 
@@ -26,13 +27,22 @@ class VPCRouteDefinition(nixops.resources.ResourceDefinition):
     def show_type(self):
         return "{0}".format(self.get_type())
 
+
 class VPCRouteState(nixops.resources.DiffEngineResourceState, EC2CommonState):
     """State of a VPC route"""
 
-    state = nixops.util.attr_property("state", nixops.resources.DiffEngineResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.DiffEngineResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("accessKeyId", None)
     _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED
-    TARGETS = ['egressOnlyInternetGatewayId', 'gatewayId', 'instanceId', 'natGatewayId', 'networkInterfaceId']
+    TARGETS = [
+        "egressOnlyInternetGatewayId",
+        "gatewayId",
+        "instanceId",
+        "natGatewayId",
+        "networkInterfaceId",
+    ]
 
     @classmethod
     def get_type(cls):
@@ -41,66 +51,96 @@ class VPCRouteState(nixops.resources.DiffEngineResourceState, EC2CommonState):
     def __init__(self, depl, name, id):
         nixops.resources.DiffEngineResourceState.__init__(self, depl, name, id)
         self._state = StateDict(depl, id)
-        self.region = self._state.get('region', None)
-        keys = ['region', 'routeTableId', 'destinationCidrBlock', 'destinationIpv6CidrBlock',
-                'egressOnlyInternetGatewayId', 'gatewayId', 'instanceId', 'natGatewayId',
-                'networkInterfaceId']
+        self.region = self._state.get("region", None)
+        keys = [
+            "region",
+            "routeTableId",
+            "destinationCidrBlock",
+            "destinationIpv6CidrBlock",
+            "egressOnlyInternetGatewayId",
+            "gatewayId",
+            "instanceId",
+            "natGatewayId",
+            "networkInterfaceId",
+        ]
         self.handle_create_route = Handler(keys, handle=self.realize_create_route)
 
     def show_type(self):
         s = super(VPCRouteState, self).show_type()
-        if self.region: s = "{0} [{1}]".format(s, self.region)
+        if self.region:
+            s = "{0} [{1}]".format(s, self.region)
         return s
 
     @property
     def resource_id(self):
-        return (self._state.get('destinationCidrBlock', None) or self._state.get('destinationIpv6CidrBlock', None))
+        return self._state.get("destinationCidrBlock", None) or self._state.get(
+            "destinationIpv6CidrBlock", None
+        )
 
     def prefix_definition(self, attr):
-        return {('resources', 'vpcRoutes'): attr}
+        return {("resources", "vpcRoutes"): attr}
 
     def get_definition_prefix(self):
         return "resources.vpcRoutes."
 
     def create_after(self, resources, defn):
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.vpc_route_table.VPCRouteTableState) or
-                isinstance(r, nixopsaws.resources.vpc_internet_gateway.VPCInternetGatewayState) or
-                isinstance(r, nixopsaws.resources.vpc_nat_gateway.VPCNatGatewayState)}
+        return {
+            r
+            for r in resources
+            if isinstance(r, nixopsaws.resources.vpc_route_table.VPCRouteTableState)
+            or isinstance(
+                r, nixopsaws.resources.vpc_internet_gateway.VPCInternetGatewayState
+            )
+            or isinstance(r, nixopsaws.resources.vpc_nat_gateway.VPCNatGatewayState)
+        }
 
     def realize_create_route(self, allow_recreate):
         config = self.get_defn()
 
         if self.state == self.UP:
             if not allow_recreate:
-                raise Exception("route {} definition changed and it needs to be recreated"
-                                " use --allow-recreate if you want to create a new one".format(self.name))
+                raise Exception(
+                    "route {} definition changed and it needs to be recreated"
+                    " use --allow-recreate if you want to create a new one".format(
+                        self.name
+                    )
+                )
             self.warn("route definition changed, recreating ...")
             self._destroy()
 
-        self._state['region'] = config['region']
+        self._state["region"] = config["region"]
 
-        rtb_id = config['routeTableId']
+        rtb_id = config["routeTableId"]
         if rtb_id.startswith("res-"):
-            res = self.depl.get_typed_resource(rtb_id[4:].split(".")[0], "vpc-route-table")
-            rtb_id = res._state['routeTableId']
+            res = self.depl.get_typed_resource(
+                rtb_id[4:].split(".")[0], "vpc-route-table"
+            )
+            rtb_id = res._state["routeTableId"]
 
         route = dict()
         config = self.get_defn()
         num_targets = 0
         for item in self.TARGETS:
             if config[item]:
-                num_targets+=1
+                num_targets += 1
                 target = item
 
         if num_targets > 1:
-            raise Exception("you should specify only 1 target from {}".format(str(self.TARGETS)))
+            raise Exception(
+                "you should specify only 1 target from {}".format(str(self.TARGETS))
+            )
 
-        if (config['destinationCidrBlock'] is not None) and (config['destinationIpv6CidrBlock'] is not None):
-            raise Exception("you can't set both destinationCidrBlock and destinationIpv6CidrBlock in one route")
+        if (config["destinationCidrBlock"] is not None) and (
+            config["destinationIpv6CidrBlock"] is not None
+        ):
+            raise Exception(
+                "you can't set both destinationCidrBlock and destinationIpv6CidrBlock in one route"
+            )
 
-        if config['destinationCidrBlock'] is not None: destination = 'destinationCidrBlock'
-        if config['destinationIpv6CidrBlock'] is not None: destination = 'destinationIpv6CidrBlock'
+        if config["destinationCidrBlock"] is not None:
+            destination = "destinationCidrBlock"
+        if config["destinationIpv6CidrBlock"] is not None:
+            destination = "destinationIpv6CidrBlock"
 
         def retrieve_defn(option):
             cfg = config[option]
@@ -113,40 +153,53 @@ class VPCRouteState(nixops.resources.DiffEngineResourceState, EC2CommonState):
             else:
                 return cfg
 
-        route['RouteTableId'] = rtb_id
+        route["RouteTableId"] = rtb_id
         route[self.upper(target)] = retrieve_defn(target)
         route[self.upper(destination)] = config[destination]
 
-        self.log("creating route {0} => {1} in route table {2}".format(retrieve_defn(target), config[destination], rtb_id))
+        self.log(
+            "creating route {0} => {1} in route table {2}".format(
+                retrieve_defn(target), config[destination], rtb_id
+            )
+        )
         self.get_client().create_route(**route)
 
         with self.depl._db:
             self.state = self.UP
             self._state[target] = route[self.upper(target)]
             self._state[destination] = config[destination]
-            self._state['routeTableId'] = rtb_id
+            self._state["routeTableId"] = rtb_id
 
     def upper(self, option):
         return "%s%s" % (option[0].upper(), option[1:])
 
     def _destroy(self):
-        if self.state != self.UP: return
-        destination = 'destinationCidrBlock' if ('destinationCidrBlock' in self._state.keys()) else 'destinationIpv6CidrBlock'
-        self.log("deleting route to {0} from route table {1}".format(self._state[destination], self._state['routeTableId']))
+        if self.state != self.UP:
+            return
+        destination = (
+            "destinationCidrBlock"
+            if ("destinationCidrBlock" in self._state.keys())
+            else "destinationIpv6CidrBlock"
+        )
+        self.log(
+            "deleting route to {0} from route table {1}".format(
+                self._state[destination], self._state["routeTableId"]
+            )
+        )
         try:
             args = dict()
             args[self.upper(destination)] = self._state[destination]
-            args['RouteTableId'] = self._state['routeTableId']
+            args["RouteTableId"] = self._state["routeTableId"]
             self.get_client().delete_route(**args)
         except botocore.exceptions.ClientError as error:
-            if error.response['Error']['Code'] == "InvalidRoute.NotFound":
+            if error.response["Error"]["Code"] == "InvalidRoute.NotFound":
                 self.warn("route was already deleted")
             else:
                 raise error
 
         with self.depl._db:
             self.state = self.MISSING
-            self._state['routeTableId'] = None
+            self._state["routeTableId"] = None
             self._state[destination] = None
             for target in self.TARGETS:
                 self._state[target] = None

--- a/nixopsaws/resources/vpc_route_table_association.py
+++ b/nixopsaws/resources/vpc_route_table_association.py
@@ -12,6 +12,7 @@ import nixopsaws.ec2_utils
 from nixops.diff import Diff, Handler
 from nixops.state import StateDict
 
+
 class VPCRouteTableAssociationDefinition(nixops.resources.ResourceDefinition):
     """Definition of a VPC route table association"""
 
@@ -26,12 +27,17 @@ class VPCRouteTableAssociationDefinition(nixops.resources.ResourceDefinition):
     def show_type(self):
         return "{0}".format(self.get_type())
 
-class VPCRouteTableAssociationState(nixops.resources.DiffEngineResourceState, EC2CommonState):
+
+class VPCRouteTableAssociationState(
+    nixops.resources.DiffEngineResourceState, EC2CommonState
+):
     """State of a VPC route table association"""
 
-    state = nixops.util.attr_property("state", nixops.resources.DiffEngineResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.DiffEngineResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("accessKeyId", None)
-    _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ['associationId']
+    _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ["associationId"]
 
     @classmethod
     def get_type(cls):
@@ -40,79 +46,110 @@ class VPCRouteTableAssociationState(nixops.resources.DiffEngineResourceState, EC
     def __init__(self, depl, name, id):
         nixops.resources.DiffEngineResourceState.__init__(self, depl, name, id)
         self._state = StateDict(depl, id)
-        self.region = self._state.get('region', None)
-        self.handle_associate_route_table = Handler(['region', 'routeTableId', 'subnetId'], handle=self.realize_associate_route_table)
+        self.region = self._state.get("region", None)
+        self.handle_associate_route_table = Handler(
+            ["region", "routeTableId", "subnetId"],
+            handle=self.realize_associate_route_table,
+        )
 
     def show_type(self):
         s = super(VPCRouteTableAssociationState, self).show_type()
-        if self.region: s = "{0} [{1}]".format(s, self.region)
+        if self.region:
+            s = "{0} [{1}]".format(s, self.region)
         return s
 
     @property
     def resource_id(self):
-        return self._state.get('associationId', None)
+        return self._state.get("associationId", None)
 
     def prefix_definition(self, attr):
-        return {('resources', 'vpcRouteTableAssociations'): attr}
+        return {("resources", "vpcRouteTableAssociations"): attr}
 
     def get_physical_spec(self):
-        return { 'associationId': self._state.get('associationId', None) }
+        return {"associationId": self._state.get("associationId", None)}
 
     def get_definition_prefix(self):
         return "resources.vpcRouteTableAssociations."
 
     def create_after(self, resources, defn):
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.vpc_route_table.VPCRouteTableState)}
+        return {
+            r
+            for r in resources
+            if isinstance(r, nixopsaws.resources.vpc_route_table.VPCRouteTableState)
+        }
 
     def realize_associate_route_table(self, allow_recreate):
         config = self.get_defn()
 
         if self.state == self.UP:
             if not allow_recreate:
-                raise Exception("route table association {} definition changed and it needs to be recreated"
-                                " use --allow-recreate if you want to create a new one".format(self._state['associationId']))
+                raise Exception(
+                    "route table association {} definition changed and it needs to be recreated"
+                    " use --allow-recreate if you want to create a new one".format(
+                        self._state["associationId"]
+                    )
+                )
             self.warn("route table association definition changed, recreating ...")
             self._destroy()
 
-        self._state['region'] = config['region']
+        self._state["region"] = config["region"]
 
-        route_table_id = config['routeTableId']
+        route_table_id = config["routeTableId"]
         if route_table_id.startswith("res-"):
-            res = self.depl.get_typed_resource(route_table_id[4:].split(".")[0], "vpc-route-table")
-            route_table_id = res._state['routeTableId']
+            res = self.depl.get_typed_resource(
+                route_table_id[4:].split(".")[0], "vpc-route-table"
+            )
+            route_table_id = res._state["routeTableId"]
 
-        subnet_id = config['subnetId']
+        subnet_id = config["subnetId"]
         if subnet_id.startswith("res-"):
-            res = self.depl.get_typed_resource(subnet_id[4:].split(".")[0], "vpc-subnet")
-            subnet_id = res._state['subnetId']
+            res = self.depl.get_typed_resource(
+                subnet_id[4:].split(".")[0], "vpc-subnet"
+            )
+            subnet_id = res._state["subnetId"]
 
-        self.log("associating route table {0} to subnet {1}".format(route_table_id, subnet_id))
-        association = self.get_client().associate_route_table(RouteTableId=route_table_id,
-                                                         SubnetId=subnet_id)
+        self.log(
+            "associating route table {0} to subnet {1}".format(
+                route_table_id, subnet_id
+            )
+        )
+        association = self.get_client().associate_route_table(
+            RouteTableId=route_table_id, SubnetId=subnet_id
+        )
 
         with self.depl._db:
             self.state = self.UP
-            self._state['routeTableId'] = route_table_id
-            self._state['subnetId'] = subnet_id
-            self._state['associationId'] = association['AssociationId']
+            self._state["routeTableId"] = route_table_id
+            self._state["subnetId"] = subnet_id
+            self._state["associationId"] = association["AssociationId"]
 
     def _destroy(self):
-        if self.state != self.UP: return
-        self.log("disassociating route table {0} from subnet {1}".format(self._state['routeTableId'], self._state['subnetId']))
+        if self.state != self.UP:
+            return
+        self.log(
+            "disassociating route table {0} from subnet {1}".format(
+                self._state["routeTableId"], self._state["subnetId"]
+            )
+        )
         try:
-            self.get_client().disassociate_route_table(AssociationId=self._state['associationId'])
+            self.get_client().disassociate_route_table(
+                AssociationId=self._state["associationId"]
+            )
         except botocore.exceptions.ClientError as error:
-            if error.response['Error']['Code'] == "InvalidAssociationID.NotFound":
-                self.warn("route table {} was already deleted".format(self._state['associationId']))
+            if error.response["Error"]["Code"] == "InvalidAssociationID.NotFound":
+                self.warn(
+                    "route table {} was already deleted".format(
+                        self._state["associationId"]
+                    )
+                )
             else:
                 raise error
 
         with self.depl._db:
             self.state = self.MISSING
-            self._state['routeTableId'] = None
-            self._state['subnetId'] = None
-            self._state['associationId'] = None
+            self._state["routeTableId"] = None
+            self._state["subnetId"] = None
+            self._state["associationId"] = None
 
     def destroy(self, wipe=False):
         self._destroy()

--- a/nixopsaws/resources/vpc_subnet.py
+++ b/nixopsaws/resources/vpc_subnet.py
@@ -12,6 +12,7 @@ import nixopsaws.ec2_utils
 from nixops.diff import Diff, Handler
 from nixops.state import StateDict
 
+
 class VPCSubnetDefinition(nixops.resources.ResourceDefinition):
     """Definition of a VPC subnet."""
 
@@ -30,9 +31,11 @@ class VPCSubnetDefinition(nixops.resources.ResourceDefinition):
 class VPCSubnetState(nixops.resources.DiffEngineResourceState, EC2CommonState):
     """State of a VPC subnet."""
 
-    state = nixops.util.attr_property("state", nixops.resources.ResourceState.MISSING, int)
+    state = nixops.util.attr_property(
+        "state", nixops.resources.ResourceState.MISSING, int
+    )
     access_key_id = nixops.util.attr_property("accessKeyId", None)
-    _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ['subnetId', 'associationId']
+    _reserved_keys = EC2CommonState.COMMON_EC2_RESERVED + ["subnetId", "associationId"]
 
     @classmethod
     def get_type(cls):
@@ -40,21 +43,29 @@ class VPCSubnetState(nixops.resources.DiffEngineResourceState, EC2CommonState):
 
     def __init__(self, depl, name, id):
         nixops.resources.DiffEngineResourceState.__init__(self, depl, name, id)
-        self.subnet_id = self._state.get('subnetId', None)
-        self.zone = self._state.get('zone', None)
-        self.handle_create_subnet = Handler(['region', 'zone', 'cidrBlock', 'vpcId'], handle=self.realize_create_subnet)
-        self.handle_map_public_ip_on_launch = Handler(['mapPublicIpOnLaunch'],
-                                                      after=[self.handle_create_subnet],
-                                                      handle=self.realize_map_public_ip_on_launch)
-        self.handle_associate_ipv6_cidr_block = Handler(
-            ['ipv6CidrBlock'],
+        self.subnet_id = self._state.get("subnetId", None)
+        self.zone = self._state.get("zone", None)
+        self.handle_create_subnet = Handler(
+            ["region", "zone", "cidrBlock", "vpcId"], handle=self.realize_create_subnet
+        )
+        self.handle_map_public_ip_on_launch = Handler(
+            ["mapPublicIpOnLaunch"],
             after=[self.handle_create_subnet],
-            handle=self.realize_associate_ipv6_cidr_block)
-        self.handle_tag_update = Handler(['tags'], after=[self.handle_create_subnet], handle=self.realize_update_tag)
+            handle=self.realize_map_public_ip_on_launch,
+        )
+        self.handle_associate_ipv6_cidr_block = Handler(
+            ["ipv6CidrBlock"],
+            after=[self.handle_create_subnet],
+            handle=self.realize_associate_ipv6_cidr_block,
+        )
+        self.handle_tag_update = Handler(
+            ["tags"], after=[self.handle_create_subnet], handle=self.realize_update_tag
+        )
 
     def show_type(self):
         s = super(VPCSubnetState, self).show_type()
-        if self.zone: s = "{0} [{1}]".format(s, self.zone)
+        if self.zone:
+            s = "{0} [{1}]".format(s, self.zone)
         return s
 
     @property
@@ -62,56 +73,68 @@ class VPCSubnetState(nixops.resources.DiffEngineResourceState, EC2CommonState):
         return self.subnet_id
 
     def prefix_definition(self, attr):
-        return {('resources', 'vpcSubnets'): attr}
+        return {("resources", "vpcSubnets"): attr}
 
     def get_physical_spec(self):
-        return {'subnetId': self.subnet_id}
+        return {"subnetId": self.subnet_id}
 
     def get_definition_prefix(self):
         return "resources.vpcSubnets."
 
     def create_after(self, resources, defn):
-        return {r for r in resources if
-                isinstance(r, nixopsaws.resources.vpc.VPCState)}
+        return {r for r in resources if isinstance(r, nixopsaws.resources.vpc.VPCState)}
 
     def create(self, defn, check, allow_reboot, allow_recreate):
-        nixops.resources.DiffEngineResourceState.create(self, defn, check, allow_reboot, allow_recreate)
+        nixops.resources.DiffEngineResourceState.create(
+            self, defn, check, allow_reboot, allow_recreate
+        )
         self.ensure_subnet_up(check)
 
     def ensure_subnet_up(self, check):
         config = self.get_defn()
-        self._state['region'] = config['region']
+        self._state["region"] = config["region"]
 
-        if self._state.get('subnetId', None):
+        if self._state.get("subnetId", None):
             if check:
                 try:
-                    self.get_client().describe_subnets(SubnetIds=[self._state['subnetId']])
+                    self.get_client().describe_subnets(
+                        SubnetIds=[self._state["subnetId"]]
+                    )
                 except botocore.exceptions.ClientError as error:
-                    if error.response['Error']['Code'] == 'InvalidSubnetID.NotFound':
-                        self.warn("subnet {} was deleted from outside nixops,"
-                                  " recreating ...".format(self._state['subnetId']))
+                    if error.response["Error"]["Code"] == "InvalidSubnetID.NotFound":
+                        self.warn(
+                            "subnet {} was deleted from outside nixops,"
+                            " recreating ...".format(self._state["subnetId"])
+                        )
                         allow_recreate = True
                         self.realize_create_subnet(allow_recreate)
                         self.realize_map_public_ip_on_launch(allow_recreate)
                     else:
                         raise error
             if self.state != self.UP:
-                self.wait_for_subnet_available(self._state['subnetId'])
+                self.wait_for_subnet_available(self._state["subnetId"])
 
     def wait_for_subnet_available(self, subnet_id):
         while True:
             response = self.get_client().describe_subnets(SubnetIds=[subnet_id])
-            if len(response['Subnets']) == 1:
-                subnet = response['Subnets'][0]
-                if subnet['State'] == "available":
+            if len(response["Subnets"]) == 1:
+                subnet = response["Subnets"][0]
+                if subnet["State"] == "available":
                     break
-                elif subnet['State'] != "pending":
-                    raise Exception("subnet {0} is in an unexpected state {1}".format(
-                        subnet_id, subnet['State']))
+                elif subnet["State"] != "pending":
+                    raise Exception(
+                        "subnet {0} is in an unexpected state {1}".format(
+                            subnet_id, subnet["State"]
+                        )
+                    )
                 self.log_continue(".")
                 time.sleep(1)
             else:
-                raise Exception("couldn't find subnet {}, please run deploy with --check".format(subnet_id))
+                raise Exception(
+                    "couldn't find subnet {}, please run deploy with --check".format(
+                        subnet_id
+                    )
+                )
         self.log_end(" done")
 
         with self.depl._db:
@@ -121,39 +144,45 @@ class VPCSubnetState(nixops.resources.DiffEngineResourceState, EC2CommonState):
         config = self.get_defn()
         if self.state == self.UP:
             if not allow_recreate:
-                raise Exception("subnet {} definition changed and it needs to be recreated"
-                                " use --allow-recreate if you want to create a new one".format(
-                                    self.subnet_id))
+                raise Exception(
+                    "subnet {} definition changed and it needs to be recreated"
+                    " use --allow-recreate if you want to create a new one".format(
+                        self.subnet_id
+                    )
+                )
             self.warn("subnet definition changed, recreating...")
             self._destroy()
 
-        self._state['region'] = config['region']
+        self._state["region"] = config["region"]
 
-        vpc_id = config['vpcId']
+        vpc_id = config["vpcId"]
 
         if vpc_id.startswith("res-"):
             res = self.depl.get_typed_resource(vpc_id[4:].split(".")[0], "vpc")
-            vpc_id = res._state['vpcId']
+            vpc_id = res._state["vpcId"]
 
-        zone = config['zone'] if config['zone'] else ''
+        zone = config["zone"] if config["zone"] else ""
         self.log("creating subnet in vpc {0}".format(vpc_id))
-        response = self.get_client().create_subnet(VpcId=vpc_id, CidrBlock=config['cidrBlock'],
-                                              AvailabilityZone=zone)
-        subnet = response.get('Subnet')
-        self.subnet_id = subnet.get('SubnetId')
-        self.zone = subnet.get('AvailabilityZone')
+        response = self.get_client().create_subnet(
+            VpcId=vpc_id, CidrBlock=config["cidrBlock"], AvailabilityZone=zone
+        )
+        subnet = response.get("Subnet")
+        self.subnet_id = subnet.get("SubnetId")
+        self.zone = subnet.get("AvailabilityZone")
 
         with self.depl._db:
             self.state = self.STARTING
-            self._state['subnetId'] = self.subnet_id
-            self._state['cidrBlock'] = config['cidrBlock']
-            self._state['zone'] = self.zone
-            self._state['vpcId'] = vpc_id
-            self._state['region'] = config['region']
+            self._state["subnetId"] = self.subnet_id
+            self._state["cidrBlock"] = config["cidrBlock"]
+            self._state["zone"] = self.zone
+            self._state["vpcId"] = vpc_id
+            self._state["region"] = config["region"]
 
         def tag_updater(tags):
-            self.get_client().create_tags(Resources=[self.subnet_id],
-                                     Tags=[{"Key": k, "Value": tags[k]} for k in tags])
+            self.get_client().create_tags(
+                Resources=[self.subnet_id],
+                Tags=[{"Key": k, "Value": tags[k]} for k in tags],
+            )
 
         self.update_tags_using(tag_updater, user_tags=config["tags"], check=True)
 
@@ -162,57 +191,67 @@ class VPCSubnetState(nixops.resources.DiffEngineResourceState, EC2CommonState):
     def realize_map_public_ip_on_launch(self, allow_recreate):
         config = self.get_defn()
         self.get_client().modify_subnet_attribute(
-            MapPublicIpOnLaunch={'Value':config['mapPublicIpOnLaunch']},
-            SubnetId=self.subnet_id)
+            MapPublicIpOnLaunch={"Value": config["mapPublicIpOnLaunch"]},
+            SubnetId=self.subnet_id,
+        )
 
         with self.depl._db:
-            self._state['mapPublicIpOnLaunch'] = config['mapPublicIpOnLaunch']
+            self._state["mapPublicIpOnLaunch"] = config["mapPublicIpOnLaunch"]
 
     def realize_associate_ipv6_cidr_block(self, allow_recreate):
         config = self.get_defn()
 
-        if config['ipv6CidrBlock'] is not None:
-            self.log("associating ipv6 cidr block {}".format(config['ipv6CidrBlock']))
+        if config["ipv6CidrBlock"] is not None:
+            self.log("associating ipv6 cidr block {}".format(config["ipv6CidrBlock"]))
             response = self.get_client().associate_subnet_cidr_block(
-                Ipv6CidrBlock=config['ipv6CidrBlock'],
-                SubnetId=self._state['subnetId'])
+                Ipv6CidrBlock=config["ipv6CidrBlock"], SubnetId=self._state["subnetId"]
+            )
         else:
             self.log("disassociating ipv6 cidr block")
             self.get_client().disassociate_subnet_cidr_block(
-                AssociationId=self._state['associationId'])
+                AssociationId=self._state["associationId"]
+            )
 
         with self.depl._db:
-            self._state["ipv6CidrBlock"] = config['ipv6CidrBlock']
-            if config['ipv6CidrBlock'] is not None:
-                self._state['associationId'] = response['Ipv6CidrBlockAssociation']['AssociationId']
+            self._state["ipv6CidrBlock"] = config["ipv6CidrBlock"]
+            if config["ipv6CidrBlock"] is not None:
+                self._state["associationId"] = response["Ipv6CidrBlockAssociation"][
+                    "AssociationId"
+                ]
 
     def realize_update_tag(self, allow_recreate):
         config = self.get_defn()
-        tags = config['tags']
+        tags = config["tags"]
         tags.update(self.get_common_tags())
-        self.get_client().create_tags(Resources=[self._state['subnetId']], Tags=[{"Key": k, "Value": tags[k]} for k in tags])
+        self.get_client().create_tags(
+            Resources=[self._state["subnetId"]],
+            Tags=[{"Key": k, "Value": tags[k]} for k in tags],
+        )
 
     def _destroy(self):
-        if self.state != (self.UP or self.STARTING): return
+        if self.state != (self.UP or self.STARTING):
+            return
         self.log("deleting subnet {0}".format(self.subnet_id))
         try:
-            #FIXME setting automatic retries for what it looks like AWS
-            #eventual consistency issues but need to check further.
-            self._retry(lambda: self.get_client().delete_subnet(SubnetId=self.subnet_id))
+            # FIXME setting automatic retries for what it looks like AWS
+            # eventual consistency issues but need to check further.
+            self._retry(
+                lambda: self.get_client().delete_subnet(SubnetId=self.subnet_id)
+            )
         except botocore.exceptions.ClientError as error:
-            if error.response['Error']['Code'] == 'InvalidSubnetID.NotFound':
+            if error.response["Error"]["Code"] == "InvalidSubnetID.NotFound":
                 self.warn("subnet {} was already deleted".format(self.subnet_id))
             else:
                 raise error
 
         with self.depl._db:
             self.state = self.MISSING
-            self._state['subnetID'] = None
-            self._state['region'] = None
-            self._state['vpcId'] = None
-            self._state['cidrBlock'] = None
-            self._state['zone'] = None
-            self._state['mapPublicIpOnLaunch'] = None
+            self._state["subnetID"] = None
+            self._state["region"] = None
+            self._state["vpcId"] = None
+            self._state["cidrBlock"] = None
+            self._state["zone"] = None
+            self._state["mapPublicIpOnLaunch"] = None
 
     def destroy(self, wipe=False):
         self._destroy()

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,20 @@
 from distutils.core import setup
 
 
-setup(name='nixops-aws',
-      version='@version@',
-      description='NixOS cloud deployment tool, but for aws',
-      url='https://github.com/NixOS/nixops-aws',
-      # TODO: add author
-      author='',
-      author_email='',
-      packages=['nixopsaws', 'nixopsaws.data', 'nixopsaws.resources', 'nixopsaws.backends'],
-      entry_points={'nixops': ['aws = nixopsaws.plugin']},
-      py_modules=['plugin']
+setup(
+    name="nixops-aws",
+    version="@version@",
+    description="NixOS cloud deployment tool, but for aws",
+    url="https://github.com/NixOS/nixops-aws",
+    # TODO: add author
+    author="",
+    author_email="",
+    packages=[
+        "nixopsaws",
+        "nixopsaws.data",
+        "nixopsaws.resources",
+        "nixopsaws.backends",
+    ],
+    entry_points={"nixops": ["aws = nixopsaws.plugin"]},
+    py_modules=["plugin"],
 )

--- a/tests.py
+++ b/tests.py
@@ -4,10 +4,19 @@ import os
 
 if __name__ == "__main__":
     config = nose.config.Config(plugins=nose.plugins.manager.DefaultPluginManager())
-    config.configure(argv=[sys.argv[0], "-e", "^coverage-tests\.py$"] +
-                     sys.argv[1:])
-    count = nose.loader.defaultTestLoader(config=config).loadTestsFromNames(['.']).countTestCases()
-    nose.main(argv=[sys.argv[0],
-                    "--process-timeout=inf",
-                    "--processes=%d".format(count),
-                    "-e", "^coverage-tests\.py$"] + sys.argv[1:])
+    config.configure(argv=[sys.argv[0], "-e", "^coverage-tests\.py$"] + sys.argv[1:])
+    count = (
+        nose.loader.defaultTestLoader(config=config)
+        .loadTestsFromNames(["."])
+        .countTestCases()
+    )
+    nose.main(
+        argv=[
+            sys.argv[0],
+            "--process-timeout=inf",
+            "--processes=%d".format(count),
+            "-e",
+            "^coverage-tests\.py$",
+        ]
+        + sys.argv[1:]
+    )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -7,10 +7,12 @@ import nixops.statefile
 
 _multiprocess_shared_ = True
 
-db_file = '%s/test.nixops' % (path.dirname(__file__))
+db_file = "%s/test.nixops" % (path.dirname(__file__))
+
 
 def setup():
     nixops.statefile.StateFile(db_file).close()
+
 
 def destroy(sf, uuid):
     depl = sf.open_deployment(uuid)
@@ -26,12 +28,13 @@ def destroy(sf, uuid):
     depl.delete()
     depl.logger.log("deployment ‘{0}’ destroyed".format(uuid))
 
+
 def teardown():
     sf = nixops.statefile.StateFile(db_file)
     uuids = sf.query_deployments()
     threads = []
     for uuid in uuids:
-        threads.append(threading.Thread(target=destroy,args=(sf, uuid)))
+        threads.append(threading.Thread(target=destroy, args=(sf, uuid)))
     for thread in threads:
         thread.start()
     for thread in threads:
@@ -41,4 +44,6 @@ def teardown():
     if not uuids_left:
         os.remove(db_file)
     else:
-        sys.stderr.write("warning: not all deployments have been destroyed; some resources may still exist!\n")
+        sys.stderr.write(
+            "warning: not all deployments have been destroyed; some resources may still exist!\n"
+        )

--- a/tests/functional/test_backups.py
+++ b/tests/functional/test_backups.py
@@ -8,43 +8,44 @@ from tests.functional import generic_deployment_test
 
 parent_dir = path.dirname(__file__)
 
+
 class TestBackups(generic_deployment_test.GenericDeploymentTest):
     _multiprocess_can_split_ = True
 
     def setup(self):
-        super(TestBackups,self).setup()
+        super(TestBackups, self).setup()
 
     def test_simple_restore_xd_device_mapping(self):
         self.depl.nix_exprs = [
-            '%s/single_machine_logical_base.nix' % (parent_dir),
-            '%s/single_machine_ec2_ebs.nix' % (parent_dir),
-            '%s/single_machine_ec2_base.nix' % (parent_dir)
+            "%s/single_machine_logical_base.nix" % (parent_dir),
+            "%s/single_machine_ec2_ebs.nix" % (parent_dir),
+            "%s/single_machine_ec2_base.nix" % (parent_dir),
         ]
         self.backup_and_restore_path()
 
     def test_raid_restore_xd_device_mapping(self):
         self.depl.nix_exprs = [
-            '%s/single_machine_logical_base.nix' % (parent_dir),
-            '%s/single_machine_ec2_ebs.nix' % (parent_dir),
-            '%s/single_machine_ec2_base.nix' % (parent_dir),
-            '%s/single_machine_ec2_raid-0.nix' % (parent_dir)
+            "%s/single_machine_logical_base.nix" % (parent_dir),
+            "%s/single_machine_ec2_ebs.nix" % (parent_dir),
+            "%s/single_machine_ec2_base.nix" % (parent_dir),
+            "%s/single_machine_ec2_raid-0.nix" % (parent_dir),
         ]
         self.backup_and_restore_path("/data")
 
     def test_simple_restore_on_nvme_device_mapping(self):
         self.depl.nix_exprs = [
-            '%s/single_machine_logical_base.nix' % (parent_dir),
-            '%s/single_machine_ec2_ebs.nix' % (parent_dir),
-            '%s/single_machine_ec2_base_nvme.nix' % (parent_dir)
+            "%s/single_machine_logical_base.nix" % (parent_dir),
+            "%s/single_machine_ec2_ebs.nix" % (parent_dir),
+            "%s/single_machine_ec2_base_nvme.nix" % (parent_dir),
         ]
         self.backup_and_restore_path()
 
     def test_raid_restore_on_nvme_device_mapping(self):
         self.depl.nix_exprs = [
-            '%s/single_machine_logical_base.nix' % (parent_dir),
-            '%s/single_machine_ec2_ebs.nix' % (parent_dir),
-            '%s/single_machine_ec2_base_nvme.nix' % (parent_dir),
-            '%s/single_machine_ec2_raid-0-nvme.nix' % (parent_dir)
+            "%s/single_machine_logical_base.nix" % (parent_dir),
+            "%s/single_machine_ec2_ebs.nix" % (parent_dir),
+            "%s/single_machine_ec2_base_nvme.nix" % (parent_dir),
+            "%s/single_machine_ec2_raid-0-nvme.nix" % (parent_dir),
         ]
         self.backup_and_restore_path("/data")
         self.check_command("mount | grep '/dev/mapper/raid-raid on /data type ext4'")
@@ -55,7 +56,7 @@ class TestBackups(generic_deployment_test.GenericDeploymentTest):
         self.check_command("echo -n important-data > %s/back-me-up" % (path))
         backup_id = self.depl.backup()
         backups = self.depl.get_backups()
-        while backups[backup_id]['status'] == "running":
+        while backups[backup_id]["status"] == "running":
             time.sleep(10)
             backups = self.depl.get_backups()
         self.check_command("rm %s/back-me-up" % (path))

--- a/tests/functional/test_deploys_spot_instance.py
+++ b/tests/functional/test_deploys_spot_instance.py
@@ -4,10 +4,11 @@ from os import path
 
 parent_dir = path.dirname(__file__)
 
+
 class TestDeploysSpotInstance(single_machine_test.SingleMachineTest):
     def run_check(self):
         self.depl.nix_exprs = self.depl.nix_exprs + [
-                '%s/single_machine_ec2_spot_instance.nix' % (parent_dir),
-                ]
+            "%s/single_machine_ec2_spot_instance.nix" % (parent_dir),
+        ]
         self.depl.deploy()
         self.check_command("test -f /etc/NIXOS")

--- a/tests/functional/test_ec2_rds_dbinstance.py
+++ b/tests/functional/test_ec2_rds_dbinstance.py
@@ -6,19 +6,20 @@ from tests.functional import generic_deployment_test
 
 parent_dir = path.dirname(__file__)
 
-logical_spec = '%s/ec2-rds-dbinstance.nix' % (parent_dir)
-sg_spec = '%s/ec2-rds-dbinstance-with-sg.nix' % (parent_dir)
+logical_spec = "%s/ec2-rds-dbinstance.nix" % (parent_dir)
+sg_spec = "%s/ec2-rds-dbinstance-with-sg.nix" % (parent_dir)
+
 
 class TestEc2RdsDbinstanceTest(generic_deployment_test.GenericDeploymentTest):
     _multiprocess_can_split_ = True
 
     def setup(self):
         super(TestEc2RdsDbinstanceTest, self).setup()
-        self.depl.nix_exprs = [ logical_spec ]
+        self.depl.nix_exprs = [logical_spec]
 
     def test_deploy(self):
         self.depl.deploy()
 
     def test_deploy_with_sg(self):
-        self.depl.nix_exprs = [ sg_spec ]
+        self.depl.nix_exprs = [sg_spec]
         self.depl.deploy()

--- a/tests/functional/test_ec2_with_nvme_device_mapping.py
+++ b/tests/functional/test_ec2_with_nvme_device_mapping.py
@@ -8,20 +8,23 @@ from tests.functional import generic_deployment_test
 
 parent_dir = path.dirname(__file__)
 
+
 class TestEc2WithNvmeDeviceMapping(generic_deployment_test.GenericDeploymentTest):
     _multiprocess_can_split_ = True
 
     def setup(self):
-        super(TestEc2WithNvmeDeviceMapping,self).setup()
+        super(TestEc2WithNvmeDeviceMapping, self).setup()
 
     def test_ec2_with_nvme_device_mapping(self):
         self.depl.nix_exprs = [
-            '%s/ec2_with_nvme_device_mapping.nix' % (parent_dir),
+            "%s/ec2_with_nvme_device_mapping.nix" % (parent_dir),
         ]
         self.depl.deploy()
         self.check_command("test -f /etc/NIXOS")
         self.check_command("lsblk | grep nvme1n1")
-        self.check_command("cat /proc/mounts | grep '/dev/nvme1n1 /data ext4 rw,relatime,data=ordered 0 0'")
+        self.check_command(
+            "cat /proc/mounts | grep '/dev/nvme1n1 /data ext4 rw,relatime,data=ordered 0 0'"
+        )
         self.check_command("touch /data/asdf")
 
     def check_command(self, command):

--- a/tests/unit/test_device_name_to_boto_expected.py
+++ b/tests/unit/test_device_name_to_boto_expected.py
@@ -4,45 +4,24 @@ from textwrap import dedent
 
 from nixops.util import device_name_to_boto_expected
 
+
 class TestDeviceNameToBotoExpected(unittest.TestCase):
     def test_device_name_to_boto_expected(self):
         self.assertEqual(
-            device_name_to_boto_expected('/dev/sdf'),
-            '/dev/sdf',
+            device_name_to_boto_expected("/dev/sdf"), "/dev/sdf",
         )
-        self.assertEqual(
-            device_name_to_boto_expected('/dev/sdg'),
-            '/dev/sdg'
-        )
-        self.assertEqual(
-            device_name_to_boto_expected('/dev/xvdf'),
-            '/dev/sdf'
-        )
-        self.assertEqual(
-            device_name_to_boto_expected('/dev/xvdg'),
-            '/dev/sdg'
-        )
-        self.assertEqual(
-            device_name_to_boto_expected('/dev/nvme1n1'),
-            '/dev/sdf'
-        )
-        self.assertEqual(
-            device_name_to_boto_expected('/dev/nvme2n1'),
-            '/dev/sdg'
-        )
+        self.assertEqual(device_name_to_boto_expected("/dev/sdg"), "/dev/sdg")
+        self.assertEqual(device_name_to_boto_expected("/dev/xvdf"), "/dev/sdf")
+        self.assertEqual(device_name_to_boto_expected("/dev/xvdg"), "/dev/sdg")
+        self.assertEqual(device_name_to_boto_expected("/dev/nvme1n1"), "/dev/sdf")
+        self.assertEqual(device_name_to_boto_expected("/dev/nvme2n1"), "/dev/sdg")
         # TODO
         # self.assertEqual(
         #     device_name_to_boto_expected('/dev/nvme26n1'),
         #     '/dev/sdg'
         # )
-        self.assertEqual(
-            device_name_to_boto_expected('/dev/nvme2n1p1'),
-            '/dev/sdg1'
-        )
-        self.assertEqual(
-            device_name_to_boto_expected('/dev/nvme2n1p6'),
-            '/dev/sdg6'
-        )
+        self.assertEqual(device_name_to_boto_expected("/dev/nvme2n1p1"), "/dev/sdg1")
+        self.assertEqual(device_name_to_boto_expected("/dev/nvme2n1p6"), "/dev/sdg6")
         # TODO
         # self.assertEqual(
         #     device_name_to_boto_expected('/dev/nvme26n1p6'),


### PR DESCRIPTION
This reformats the code using black, making no manual changes. We use this in
formatting NixOS module python code, and it keeps the code looking reasonably
good with little/no effort required from maintainers or code reviewers.

This diff can be reproduced from scratch by checking out master and re-running black.