### PR TITLE
Fix dev-shell exclusion reference to non-existent target

### DIFF
--- a/dev-shell
+++ b/dev-shell
@@ -1,3 +1,3 @@
-#! /bin/sh -e
+#!/bin/sh -e
 SYSTEM=$(nix-instantiate --eval --expr "builtins.currentSystem")
-exec nix-shell release.nix -A build.$SYSTEM --exclude tarball "$@"
+exec nix-shell release.nix -A build.$SYSTEM "$@"


### PR DESCRIPTION
The `tarball` target does not exist in `nixops-aws`; this was copied over from
`nixops` and not removed on the plugin separation.