### PR TITLE
autoflake: remove unused stdlib imports

### DIFF
--- a/coverage-tests.py
+++ b/coverage-tests.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python2
 import nose
 import sys
-import os
 
 if __name__ == "__main__":
     nose.main(

--- a/nixopsaws/backends/ec2.py
+++ b/nixopsaws/backends/ec2.py
@@ -1,11 +1,7 @@
 # -*- coding: utf-8 -*-
-import os
-import os.path
-import sys
 import re
 import time
 import math
-import shutil
 import calendar
 import boto.ec2
 import boto.ec2.blockdevicemapping
@@ -23,7 +19,6 @@ from nixops.util import (
 )
 import nixopsaws.ec2_utils
 import nixops.known_hosts
-from xml import etree
 import datetime
 import boto3
 

--- a/nixopsaws/resources/cloudwatch_metric_alarm.py
+++ b/nixopsaws/resources/cloudwatch_metric_alarm.py
@@ -3,15 +3,12 @@
 # Automatic provisioning of AWS Cloudwatch Metric Alarms.
 
 import os
-import time
 import botocore
 import boto3
-import uuid
 import nixops.util
 import nixops.resources
 import nixopsaws.ec2_utils
 from nixopsaws.resources.ec2_common import EC2CommonState
-from pprint import pprint
 
 
 class CloudwatchMetricAlarmDefinition(nixops.resources.ResourceDefinition):

--- a/nixopsaws/resources/ebs_volume.py
+++ b/nixopsaws/resources/ebs_volume.py
@@ -2,7 +2,6 @@
 
 # Automatic provisioning of AWS EBS volumes.
 
-import time
 import boto.ec2
 import nixops.util
 import nixopsaws.ec2_utils

--- a/nixopsaws/resources/elastic_file_system_mount_target.py
+++ b/nixopsaws/resources/elastic_file_system_mount_target.py
@@ -2,7 +2,6 @@
 
 # AWS Elastic File System mount targets.
 
-import uuid
 import boto3
 import botocore
 import nixops.util

--- a/nixopsaws/resources/elastic_ip.py
+++ b/nixopsaws/resources/elastic_ip.py
@@ -2,7 +2,6 @@
 
 # Automatic provisioning of EC2 elastic IP addresses.
 
-import time
 import nixops.util
 import nixops.resources
 import nixopsaws.ec2_utils

--- a/nixopsaws/resources/iam_role.py
+++ b/nixopsaws/resources/iam_role.py
@@ -2,14 +2,11 @@
 
 # Automatic provisioning of AWS IAM roles.
 
-import time
 import boto
 import boto.iam
 import nixops.util
 import nixops.resources
 import nixopsaws.ec2_utils
-from xml.etree import ElementTree
-from pprint import pprint
 from boto.exception import BotoServerError
 
 

--- a/nixopsaws/resources/route53_health_check.py
+++ b/nixopsaws/resources/route53_health_check.py
@@ -3,14 +3,12 @@
 # Automatic provisioning of AWS Route53 Health Check.
 
 import os
-import time
 import botocore
 import boto3
 import uuid
 import nixops.util
 import nixops.resources
 import nixopsaws.ec2_utils
-from pprint import pprint
 import copy
 
 # boto3.set_stream_logger(name='botocore')

--- a/nixopsaws/resources/route53_hosted_zone.py
+++ b/nixopsaws/resources/route53_hosted_zone.py
@@ -3,14 +3,12 @@
 # Automatic provisioning of AWS Route53 Hosted Zones.
 
 import os
-import time
 import botocore
 import boto3
 import uuid
 import nixops.util
 import nixops.resources
 import nixopsaws.ec2_utils
-from pprint import pprint
 
 # boto3.set_stream_logger(name='botocore')
 

--- a/nixopsaws/resources/s3_bucket.py
+++ b/nixopsaws/resources/s3_bucket.py
@@ -2,7 +2,6 @@
 
 # Automatic provisioning of AWS S3 buckets.
 
-import time
 import botocore
 import boto3
 import json

--- a/nixopsaws/resources/sns_topic.py
+++ b/nixopsaws/resources/sns_topic.py
@@ -7,7 +7,6 @@ import boto.sns
 import nixops.util
 import nixops.resources
 import nixopsaws.ec2_utils
-from xml.etree import ElementTree
 
 
 class SNSTopicDefinition(nixops.resources.ResourceDefinition):

--- a/nixopsaws/resources/vpc_customer_gateway.py
+++ b/nixopsaws/resources/vpc_customer_gateway.py
@@ -2,7 +2,6 @@
 
 # Automatic provisioning of AWS VPC customer gateways.
 
-import os
 
 import boto3
 import botocore

--- a/nixopsaws/resources/vpc_dhcp_options.py
+++ b/nixopsaws/resources/vpc_dhcp_options.py
@@ -2,8 +2,6 @@
 
 # Automatic provisioning of AWS VPC DHCP options.
 
-import os
-import json
 
 import boto3
 import botocore

--- a/nixopsaws/resources/vpc_internet_gateway.py
+++ b/nixopsaws/resources/vpc_internet_gateway.py
@@ -2,7 +2,6 @@
 
 # Automatic provisioning of AWS VPC internet gateways.
 
-import os
 
 import boto3
 import botocore

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,5 @@
 import nose
 import sys
-import os
 
 if __name__ == "__main__":
     config = nose.config.Config(plugins=nose.plugins.manager.DefaultPluginManager())

--- a/tests/functional/__init__.py
+++ b/tests/functional/__init__.py
@@ -1,5 +1,3 @@
-import os
-from os import path
 import nixops.statefile
 from tests import db_file
 

--- a/tests/functional/test_ec2_with_nvme_device_mapping.py
+++ b/tests/functional/test_ec2_with_nvme_device_mapping.py
@@ -1,4 +1,3 @@
-import time
 
 from os import path
 

--- a/tests/functional/test_ec2_with_nvme_device_mapping.py
+++ b/tests/functional/test_ec2_with_nvme_device_mapping.py
@@ -1,4 +1,3 @@
-
 from os import path
 
 from nose import tools

--- a/tests/unit/test_device_name_to_boto_expected.py
+++ b/tests/unit/test_device_name_to_boto_expected.py
@@ -1,6 +1,5 @@
 import unittest
 
-from textwrap import dedent
 
 from nixops.util import device_name_to_boto_expected
 


### PR DESCRIPTION
This runs `autoflake --in-place **/*.py` to remove unused std library imports.
Note that there are quite a few unused non-stdlib imports as well, but removing
those is slightly riskier as they could have import side-effects, so they should
be done in a second pass with a reduced diff.

https://pypi.org/project/autoflake/