### PR TITLE
py3 prep: remove use of cmp()

### DIFF
--- a/nixopsaws/backends/ec2.py
+++ b/nixopsaws/backends/ec2.py
@@ -1790,10 +1790,8 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
             raise Exception("hosted zone for {0} not found".format(hosted_zone))
 
         # use hosted zone with longest match
-        zones = sorted(
-            zones, cmp=lambda a, b: cmp(len(a.Name), len(b.Name)), reverse=True
-        )
-        zoneid = zones[0]["Id"].split("/")[2]
+        longest_zone = max(zones, key=lambda x: len(x.Name))
+        zoneid = longest_zone["Id"].split("/")[2]
         dns_name = "{0}.".format(self.dns_hostname)
 
         prev_a_rrs = [


### PR DESCRIPTION
The cmp() function was removed in python3 [1], and while there is a workaround
listed, in this particular case we only need the `max` value and that's it.
Aside from being simpler and py2/py3 compatible, also happens to be more performant.

Partial work item for #29. Note that `2to3` *cannot* fix this particular one,
hence why it's being sent in a separate PR for code review.

[1] https://docs.python.org/3.0/whatsnew/3.0.html#ordering-comparisons