### PR TITLE
py3 prep: relative imports and exception syntax

### DIFF
--- a/nixopsaws/resources/__init__.py
+++ b/nixopsaws/resources/__init__.py
@@ -1,38 +1,39 @@
-import aws_vpn_connection
-import aws_vpn_connection_route
-import aws_vpn_gateway
-import cloudwatch_log_group
-import cloudwatch_log_stream
-import cloudwatch_metric_alarm
-import ebs_volume
-import ec2_common
-import ec2_keypair
-import ec2_placement_group
-import ec2_rds_dbinstance
-import ec2_rds_dbsecurity_group
-import ec2_security_group
-import efs_common
-import elastic_file_system
-import elastic_file_system_mount_target
-import elastic_ip
-import iam_role
-import route53_health_check
-import route53_hosted_zone
-import route53_recordset
-import s3_bucket
-import sns_topic
-import sqs_queue
-import vpc
-import vpc_customer_gateway
-import vpc_dhcp_options
-import vpc_egress_only_internet_gateway
-import vpc_endpoint
-import vpc_internet_gateway
-import vpc_nat_gateway
-import vpc_network_acl
-import vpc_network_interface
-import vpc_network_interface_attachment
-import vpc_route
-import vpc_route_table
-import vpc_route_table_association
-import vpc_subnet
+from __future__ import absolute_import
+from . import aws_vpn_connection
+from . import aws_vpn_connection_route
+from . import aws_vpn_gateway
+from . import cloudwatch_log_group
+from . import cloudwatch_log_stream
+from . import cloudwatch_metric_alarm
+from . import ebs_volume
+from . import ec2_common
+from . import ec2_keypair
+from . import ec2_placement_group
+from . import ec2_rds_dbinstance
+from . import ec2_rds_dbsecurity_group
+from . import ec2_security_group
+from . import efs_common
+from . import elastic_file_system
+from . import elastic_file_system_mount_target
+from . import elastic_ip
+from . import iam_role
+from . import route53_health_check
+from . import route53_hosted_zone
+from . import route53_recordset
+from . import s3_bucket
+from . import sns_topic
+from . import sqs_queue
+from . import vpc
+from . import vpc_customer_gateway
+from . import vpc_dhcp_options
+from . import vpc_egress_only_internet_gateway
+from . import vpc_endpoint
+from . import vpc_internet_gateway
+from . import vpc_nat_gateway
+from . import vpc_network_acl
+from . import vpc_network_interface
+from . import vpc_network_interface_attachment
+from . import vpc_route
+from . import vpc_route_table
+from . import vpc_route_table_association
+from . import vpc_subnet

--- a/nixopsaws/resources/cloudwatch_log_group.py
+++ b/nixopsaws/resources/cloudwatch_log_group.py
@@ -85,7 +85,7 @@ class CloudWatchLogGroupState(nixops.resources.ResourceState):
         self.log("destroying cloudwatch log group ‘{0}’...".format(self.log_group_name))
         try:
             self._conn.delete_log_group(self.log_group_name)
-        except boto.logs.exceptions.ResourceNotFoundException, e:
+        except boto.logs.exceptions.ResourceNotFoundException as e:
             self.log(
                 "the log group ‘{0}’ was already deleted".format(self.log_group_name)
             )

--- a/nixopsaws/resources/cloudwatch_log_stream.py
+++ b/nixopsaws/resources/cloudwatch_log_stream.py
@@ -87,7 +87,7 @@ class CloudWatchLogStreamState(nixops.resources.ResourceState):
             self._conn.delete_log_stream(
                 log_group_name=self.log_group_name, log_stream_name=self.log_stream_name
             )
-        except boto.logs.exceptions.ResourceNotFoundException, e:
+        except boto.logs.exceptions.ResourceNotFoundException as e:
             self.log(
                 "the log group ‘{0}’ or log stream ‘{1}’ was already deleted".format(
                     self.log_group_name, self.log_stream_name

--- a/nixopsaws/resources/ebs_volume.py
+++ b/nixopsaws/resources/ebs_volume.py
@@ -2,12 +2,13 @@
 
 # Automatic provisioning of AWS EBS volumes.
 
+from __future__ import absolute_import
 import boto.ec2
 import nixops.util
 import nixopsaws.ec2_utils
 import nixops.resources
 import botocore.exceptions
-import ec2_common
+from . import ec2_common
 
 
 class EBSVolumeDefinition(nixops.resources.ResourceDefinition):

--- a/nixopsaws/resources/elastic_file_system.py
+++ b/nixopsaws/resources/elastic_file_system.py
@@ -2,14 +2,15 @@
 
 # AWS Elastic File Systems.
 
+from __future__ import absolute_import
 import uuid
 import boto3
 import botocore
 import nixops.util
 import nixopsaws.ec2_utils
 import nixops.resources
-import ec2_common
-import efs_common
+from . import ec2_common
+from . import efs_common
 import time
 
 

--- a/nixopsaws/resources/elastic_file_system_mount_target.py
+++ b/nixopsaws/resources/elastic_file_system_mount_target.py
@@ -2,15 +2,16 @@
 
 # AWS Elastic File System mount targets.
 
+from __future__ import absolute_import
 import boto3
 import botocore
 import nixops.util
 import nixopsaws.ec2_utils
 import nixops.resources
-import ec2_common
-import efs_common
-import ec2_security_group
-import elastic_file_system
+from . import ec2_common
+from . import efs_common
+from . import ec2_security_group
+from . import elastic_file_system
 import time
 
 


### PR DESCRIPTION
This runs two more fixes that are safe to merge in python2 for continued
progress towards #29:

1. Converting `except T, R` to `except T as R`. Both work in python2, but only
   the latter works in python3.
   https://docs.python.org/3.0/whatsnew/3.0.html#changed-syntax

2. Converting module imports to relative imports.

CC @grahamc @AmineChikhaoui 