### PR TITLE
py3-prep: fix filter with list comprehensions

### DIFF
--- a/nixopsaws/backends/ec2.py
+++ b/nixopsaws/backends/ec2.py
@@ -858,16 +858,14 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
                     self.ssh_pinged = False
 
     def security_groups_to_ids(self, subnetId, groups):
-        sg_names = filter(lambda g: not g.startswith("sg-"), groups)
+        sg_names = [g for g in groups if not g.startswith("sg-")]
         if sg_names != [] and subnetId != "":
             self.connect_vpc()
             vpc_id = self._conn_vpc.get_all_subnets([subnetId])[0].vpc_id
-            groups = map(
-                lambda g: nixopsaws.ec2_utils.name_to_security_group(
-                    self._conn, g, vpc_id
-                ),
-                groups,
-            )
+            groups = [
+                nixopsaws.ec2_utils.name_to_security_group(self._conn, g, vpc_id)
+                for g in groups
+            ]
 
         return groups
 

--- a/nixopsaws/resources/elastic_file_system_mount_target.py
+++ b/nixopsaws/resources/elastic_file_system_mount_target.py
@@ -205,7 +205,7 @@ class ElasticFileSystemMountTargetState(
         conn = nixopsaws.ec2_utils.connect(region, access_key_id)
         conn_vpc = nixopsaws.ec2_utils.connect_vpc(region, access_key_id)
 
-        sg_names = filter(lambda g: not g.startswith("sg-"), groups)
+        sg_names = [g for g in groups if not g.startswith("sg-")]
         if sg_names != [] and subnetId != "":
             vpc_id = conn_vpc.get_all_subnets([subnetId])[0].vpc_id
             groups = map(

--- a/nixopsaws/resources/route53_recordset.py
+++ b/nixopsaws/resources/route53_recordset.py
@@ -158,9 +158,7 @@ class Route53RecordSetState(nixops.resources.ResourceState):
                     if defn.zone_name.endswith(".")
                     else (defn.zone_name + ".")
                 )
-                zones = filter(
-                    (lambda zone: zone["Name"] == zone_name), response["HostedZones"]
-                )
+                zones = [z for z in response["HostedZones"] if z["Name"] == zone_name]
                 if len(zones) == 0:
                     raise Exception("Can't find zone id")
                 elif len(zones) > 1:


### PR DESCRIPTION
In py2, filter returned a list; in py3, it returns an iterator, which can't be indexed.

Per upstream guidelines [1], while it is possible to just add a `list()` cast,
it's more idiomatic to use a list comprehension for filtering. This is more
pythonic regardless, and still py2 compatible.

Partial progress towards #29

CC @grahamc @AmineChikhaoui 

[1] https://docs.python.org/3.0/whatsnew/3.0.html#views-and-iterators-instead-of-lists