### PR TITLE
py3-prep: fix map with list comprehensions

### DIFF
--- a/nixopsaws/backends/ec2.py
+++ b/nixopsaws/backends/ec2.py
@@ -862,12 +862,10 @@ class EC2State(MachineState, nixopsaws.resources.ec2_common.EC2CommonState):
         if sg_names != [] and subnetId != "":
             self.connect_vpc()
             vpc_id = self._conn_vpc.get_all_subnets([subnetId])[0].vpc_id
-            groups = map(
-                lambda g: nixopsaws.ec2_utils.name_to_security_group(
-                    self._conn, g, vpc_id
-                ),
-                groups,
-            )
+            groups = [
+                nixopsaws.ec2_utils.name_to_security_group(self._conn, g, vpc_id)
+                for g in groups
+            ]
 
         return groups
 

--- a/nixopsaws/resources/cloudwatch_metric_alarm.py
+++ b/nixopsaws/resources/cloudwatch_metric_alarm.py
@@ -127,7 +127,7 @@ class CloudwatchMetricAlarmState(nixops.resources.ResourceState):
 
             return kv
 
-        cfg["Dimensions"] = map(resolve_values, defn.dimensions)
+        cfg["Dimensions"] = [resolve_values(v) for v in defn.dimensions]
 
         def resolve_action(a):
             if a.startswith("res-"):
@@ -142,11 +142,11 @@ class CloudwatchMetricAlarmState(nixops.resources.ResourceState):
             return a
 
         # resolve sns topics
-        cfg["AlarmActions"] = map(resolve_action, defn.alarm_actions)
-        cfg["OKActions"] = map(resolve_action, defn.ok_actions)
-        cfg["InsufficientDataActions"] = map(
-            resolve_action, defn.insufficient_data_actions
-        )
+        cfg["AlarmActions"] = [resolve_action(a) for a in defn.alarm_actions]
+        cfg["OKActions"] = [resolve_action(a) for a in defn.ok_actions]
+        cfg["InsufficientDataActions"] = [
+            resolve_action(a) for a in defn.insufficient_data_actions
+        ]
 
         if self.put_config != cfg or check:
             client.put_metric_alarm(**cfg)

--- a/nixopsaws/resources/elastic_file_system_mount_target.py
+++ b/nixopsaws/resources/elastic_file_system_mount_target.py
@@ -208,9 +208,9 @@ class ElasticFileSystemMountTargetState(
         sg_names = filter(lambda g: not g.startswith("sg-"), groups)
         if sg_names != [] and subnetId != "":
             vpc_id = conn_vpc.get_all_subnets([subnetId])[0].vpc_id
-            groups = map(
-                lambda g: nixopsaws.ec2_utils.name_to_security_group(conn, g, vpc_id),
-                groups,
-            )
+            groups = [
+                nixopsaws.ec2_utils.name_to_security_group(conn, g, vpc_id)
+                for g in groups
+            ]
 
         return groups

--- a/nixopsaws/resources/route53_health_check.py
+++ b/nixopsaws/resources/route53_health_check.py
@@ -134,9 +134,9 @@ class Route53HealthCheckState(nixops.resources.ResourceState):
             }
 
         if defn.type == "CALCULATED":
-            cfg["ChildHealthChecks"] = map(
-                self.resolve_health_check, defn.child_health_checks
-            )
+            cfg["ChildHealthChecks"] = [
+                self.resolve_health_check(c) for c in defn.child_health_checks
+            ]
             cfg["HealthThreshold"] = defn.health_threshold
         else:
             cfg["RequestInterval"] = defn.request_interval

--- a/nixopsaws/resources/route53_hosted_zone.py
+++ b/nixopsaws/resources/route53_hosted_zone.py
@@ -31,7 +31,8 @@ class Route53HostedZoneDefinition(nixops.resources.ResourceDefinition):
         self.private_zone = config["privateZone"]
         self.zone_name = config["name"]
         self.associated_vpcs = config["associatedVPCs"]
-        map(lambda x: x.pop("_module"), self.associated_vpcs)
+        for vpc in self.associated_vpcs:
+            vpc.pop("_module")
 
 
 class Route53HostedZoneState(nixops.resources.ResourceState):

--- a/nixopsaws/resources/route53_recordset.py
+++ b/nixopsaws/resources/route53_recordset.py
@@ -221,7 +221,7 @@ class Route53RecordSetState(nixops.resources.ResourceState):
             else:
                 return v
 
-        defn.record_values = map(resolve_machine_ip, defn.record_values)
+        defn.record_values = [resolve_machine_ip(m) for m in defn.record_values]
 
         changed = (
             self.record_values != defn.record_values
@@ -268,9 +268,7 @@ class Route53RecordSetState(nixops.resources.ResourceState):
                         "Name": obj.domain_name,
                         "Type": obj.record_type,
                         "TTL": int(obj.ttl),
-                        "ResourceRecords": map(
-                            lambda rv: {"Value": rv}, obj.record_values
-                        ),
+                        "ResourceRecords": [{"Value": rv} for rv in obj.record_values],
                     },
                 },
             ]


### PR DESCRIPTION
In py2, map returned a list; in py3, it returns an iterator, which can't be indexed.

Per upstream guidelines [1], while it is possible to just add a list() cast,
it's more idiomatic to use a list comprehension for mapping. This is more
pythonic regardless, and still py2 compatible.

Partial progress towards #29

CC @grahamc @AmineChikhaoui

[1] https://docs.python.org/3.0/whatsnew/3.0.html#views-and-iterators-instead-of-lists