### PR TITLE
py3 prep: foo.values() does not return an indexable list

### DIFF
--- a/tests/functional/test_backups.py
+++ b/tests/functional/test_backups.py
@@ -2,7 +2,6 @@ import time
 
 from os import path
 
-from nose import tools
 
 from tests.functional import generic_deployment_test
 
@@ -65,5 +64,5 @@ class TestBackups(generic_deployment_test.GenericDeploymentTest):
 
     def check_command(self, command):
         self.depl.evaluate()
-        machine = self.depl.machines.values()[0]
+        machine = list(self.depl.machines.values())[0]
         return machine.run_command(command)

--- a/tests/functional/test_deploys_spot_instance.py
+++ b/tests/functional/test_deploys_spot_instance.py
@@ -1,4 +1,3 @@
-from nose import tools
 from tests.functional import single_machine_test
 from os import path
 

--- a/tests/functional/test_ec2_rds_dbinstance.py
+++ b/tests/functional/test_ec2_rds_dbinstance.py
@@ -1,6 +1,5 @@
 from os import path
 
-from nose import tools
 
 from tests.functional import generic_deployment_test
 

--- a/tests/functional/test_ec2_with_nvme_device_mapping.py
+++ b/tests/functional/test_ec2_with_nvme_device_mapping.py
@@ -1,6 +1,5 @@
 from os import path
 
-from nose import tools
 
 from tests.functional import generic_deployment_test
 
@@ -27,5 +26,5 @@ class TestEc2WithNvmeDeviceMapping(generic_deployment_test.GenericDeploymentTest
 
     def check_command(self, command):
         self.depl.evaluate()
-        machine = self.depl.machines.values()[0]
+        machine = list(self.depl.machines.values())[0]
         return machine.run_command(command)

--- a/tests/functional/vpc.py
+++ b/tests/functional/vpc.py
@@ -2,10 +2,8 @@ from os import path
 import tempfile
 
 from nose import tools
-from nose.plugins.attrib import attr
-import boto3
 
-from nixops.nix_expr import RawValue, Function, Call, py2nix
+from nixops.nix_expr import py2nix
 import nixops.util
 from tests.functional import generic_deployment_test
 


### PR DESCRIPTION
Casting to a list is a no-op in py2, but in py3 we cannot index [0] without it.

Partial progress towards #29.

This commit also removes unused imports from test case files as a general cleanup.

CC @grahamc @AmineChikhaoui