### PR TITLE
Migrate nixops-aws to python3

### DIFF
--- a/nixopsaws/resources/__init__.py
+++ b/nixopsaws/resources/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from . import aws_vpn_connection
 from . import aws_vpn_connection_route
 from . import aws_vpn_gateway

--- a/nixopsaws/resources/ebs_volume.py
+++ b/nixopsaws/resources/ebs_volume.py
@@ -2,7 +2,7 @@
 
 # Automatic provisioning of AWS EBS volumes.
 
-from __future__ import absolute_import
+
 import boto.ec2
 import nixops.util
 import nixopsaws.ec2_utils

--- a/nixopsaws/resources/ec2_placement_group.py
+++ b/nixopsaws/resources/ec2_placement_group.py
@@ -110,7 +110,7 @@ class EC2PlacementGroupState(nixops.resources.ResourceState):
                     self.state = self.UP
                     self.placement_group_strategy = grp.strategy
                 except boto.exception.EC2ResponseError as e:
-                    if e.error_code == u"InvalidGroup.NotFound":
+                    if e.error_code == "InvalidGroup.NotFound":
                         self.state = self.Missing
                     else:
                         raise
@@ -129,7 +129,7 @@ class EC2PlacementGroupState(nixops.resources.ResourceState):
             except boto.exception.EC2ResponseError as e:
                 if (
                     self.state != self.UNKNOWN
-                    or e.error_code != u"InvalidGroup.Duplicate"
+                    or e.error_code != "InvalidGroup.Duplicate"
                 ):
                     raise
 
@@ -146,7 +146,7 @@ class EC2PlacementGroupState(nixops.resources.ResourceState):
             try:
                 conn.delete_placement_group(group["name"])
             except boto.exception.EC2ResponseError as e:
-                if e.error_code != u"InvalidGroup.NotFound":
+                if e.error_code != "InvalidGroup.NotFound":
                     raise
         self.old_placement_groups = []
 

--- a/nixopsaws/resources/ec2_rds_dbinstance.py
+++ b/nixopsaws/resources/ec2_rds_dbinstance.py
@@ -184,7 +184,7 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState):
         try:
             dbinstance = self._conn.get_all_dbinstances(instance_id=instance_id)[0]
         except boto.exception.BotoServerError as bse:
-            if bse.error_code == u"DBInstanceNotFound":
+            if bse.error_code == "DBInstanceNotFound":
                 dbinstance = None
             else:
                 raise
@@ -275,7 +275,7 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState):
 
     def _compare_instance_id(self, instance_id):
         # take care when comparing instance ids, as aws lowercases and converts to unicode
-        return unicode(self.rds_dbinstance_id).lower() == unicode(instance_id).lower()
+        return str(self.rds_dbinstance_id).lower() == str(instance_id).lower()
 
     def fetch_security_group_resources(self, config):
         security_groups = []

--- a/nixopsaws/resources/ec2_security_group.py
+++ b/nixopsaws/resources/ec2_security_group.py
@@ -194,7 +194,7 @@ class EC2SecurityGroupState(nixops.resources.ResourceState):
                             rules.append(new_rule)
                     self.security_group_rules = rules
                 except boto.exception.EC2ResponseError as e:
-                    if e.error_code == u"InvalidGroup.NotFound":
+                    if e.error_code == "InvalidGroup.NotFound":
                         self.state = self.MISSING
                     else:
                         raise
@@ -228,7 +228,7 @@ class EC2SecurityGroupState(nixops.resources.ResourceState):
             except boto.exception.EC2ResponseError as e:
                 if (
                     self.state != self.UNKNOWN
-                    or e.error_code != u"InvalidGroup.Duplicate"
+                    or e.error_code != "InvalidGroup.Duplicate"
                 ):
                     raise
             self.state = self.STARTING  # ugh
@@ -284,7 +284,7 @@ class EC2SecurityGroupState(nixops.resources.ResourceState):
                             )
                         )
                 except boto.exception.EC2ResponseError as e:
-                    if e.error_code != u"InvalidPermission.Duplicate":
+                    if e.error_code != "InvalidPermission.Duplicate":
                         raise
 
         if old_rules:
@@ -345,7 +345,7 @@ class EC2SecurityGroupState(nixops.resources.ResourceState):
             try:
                 conn.delete_security_group(group["name"])
             except boto.exception.EC2ResponseError as e:
-                if e.error_code != u"InvalidGroup.NotFound":
+                if e.error_code != "InvalidGroup.NotFound":
                     raise
         self.old_security_groups = []
 
@@ -365,7 +365,7 @@ class EC2SecurityGroupState(nixops.resources.ResourceState):
                     error_codes=["DependencyViolation"],
                 )
             except boto.exception.EC2ResponseError as e:
-                if e.error_code != u"InvalidGroup.NotFound":
+                if e.error_code != "InvalidGroup.NotFound":
                     raise
 
             self.state = self.MISSING

--- a/nixopsaws/resources/elastic_file_system.py
+++ b/nixopsaws/resources/elastic_file_system.py
@@ -2,7 +2,7 @@
 
 # AWS Elastic File Systems.
 
-from __future__ import absolute_import
+
 import uuid
 import boto3
 import botocore

--- a/nixopsaws/resources/elastic_file_system_mount_target.py
+++ b/nixopsaws/resources/elastic_file_system_mount_target.py
@@ -2,7 +2,7 @@
 
 # AWS Elastic File System mount targets.
 
-from __future__ import absolute_import
+
 import boto3
 import botocore
 import nixops.util

--- a/release.nix
+++ b/release.nix
@@ -15,7 +15,7 @@ rec {
   build = pkgs.lib.genAttrs [ "x86_64-linux" "i686-linux" "x86_64-darwin" ] (system:
     with import nixpkgs { inherit system; };
 
-    python2Packages.buildPythonApplication rec {
+    python3Packages.buildPythonApplication rec {
       pname = "nixops-aws";
       inherit version;
       namePrefix = "";
@@ -26,8 +26,8 @@ rec {
         substituteAllInPlace setup.py
       '';
 
-      buildInputs = with python2Packages; [ nose coverage ];
-      propagatedBuildInputs = with python2Packages; [ boto boto3 ];
+      buildInputs = with python3Packages; [ nose coverage ];
+      propagatedBuildInputs = with python3Packages; [ boto boto3 ];
 
       # For "nix-build --run-env".
       shellHook = ''


### PR DESCRIPTION
This does a 1-way migration to python3, and fully resolves #29.

Aside from the `release.nix`, there are no manual changes in this PR. It was
generated with:

    2to3 -n -w **/*.py -x dict -x print
    black .

We have already fixed the `print` function in a previous PR, as well as all of
the dictionary iterators. `2to3` is not particularly smart about this and will
add a `list()` cast just about everywhere otherwise.

CC @grahamc @AmineChikhaoui