### PR TITLE
Remove unused imports

### DIFF
--- a/nixopsaws/backends/ec2.py
+++ b/nixopsaws/backends/ec2.py
@@ -8,8 +8,6 @@ import boto.ec2.blockdevicemapping
 import boto.ec2.networkinterface
 from nixops.backends import MachineDefinition, MachineState
 from nixops.nix_expr import Function, Call, RawValue
-from nixopsaws.resources.ebs_volume import EBSVolumeState
-from nixopsaws.resources.elastic_ip import ElasticIPState
 import nixopsaws.resources.ec2_common
 import nixopsaws.resources
 from nixops.util import (
@@ -20,7 +18,6 @@ from nixops.util import (
 import nixopsaws.ec2_utils
 import nixops.known_hosts
 import datetime
-import boto3
 
 
 class EC2InstanceDisappeared(Exception):

--- a/nixopsaws/resources/aws_vpn_connection.py
+++ b/nixopsaws/resources/aws_vpn_connection.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from nixops.state import StateDict
-from nixops.diff import Diff, Handler
+from nixops.diff import Handler
 import nixops.util
 import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState

--- a/nixopsaws/resources/aws_vpn_connection_route.py
+++ b/nixopsaws/resources/aws_vpn_connection_route.py
@@ -6,7 +6,7 @@ import nixops.util
 import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState
 import nixopsaws.ec2_utils
-from nixops.diff import Diff, Handler
+from nixops.diff import Handler
 from nixops.state import StateDict
 
 

--- a/nixopsaws/resources/aws_vpn_gateway.py
+++ b/nixopsaws/resources/aws_vpn_gateway.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from nixops.state import StateDict
-from nixops.diff import Diff, Handler
+from nixops.diff import Handler
 import nixops.util
 import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState

--- a/nixopsaws/resources/cloudwatch_metric_alarm.py
+++ b/nixopsaws/resources/cloudwatch_metric_alarm.py
@@ -8,7 +8,6 @@ import boto3
 import nixops.util
 import nixops.resources
 import nixopsaws.ec2_utils
-from nixopsaws.resources.ec2_common import EC2CommonState
 
 
 class CloudwatchMetricAlarmDefinition(nixops.resources.ResourceDefinition):

--- a/nixopsaws/resources/ebs_volume.py
+++ b/nixopsaws/resources/ebs_volume.py
@@ -3,7 +3,6 @@
 # Automatic provisioning of AWS EBS volumes.
 
 
-import boto.ec2
 import nixops.util
 import nixopsaws.ec2_utils
 import nixops.resources

--- a/nixopsaws/resources/ec2_common.py
+++ b/nixopsaws/resources/ec2_common.py
@@ -5,7 +5,6 @@ import boto3
 
 import nixops.util
 import nixops.resources
-from nixops.diff import Diff, Handler
 import nixopsaws.ec2_utils
 
 

--- a/nixopsaws/resources/ec2_rds_dbsecurity_group.py
+++ b/nixopsaws/resources/ec2_rds_dbsecurity_group.py
@@ -1,12 +1,10 @@
-import boto3
 import botocore.exceptions
 import botocore.errorfactory
 
 import nixops.util
 import nixops.resources
-import nixopsaws.ec2_utils
 from nixopsaws.resources.ec2_common import EC2CommonState
-from nixops.diff import Diff, Handler
+from nixops.diff import Handler
 
 
 class EC2RDSDbSecurityGroupDefinition(nixops.resources.ResourceDefinition):

--- a/nixopsaws/resources/elastic_file_system.py
+++ b/nixopsaws/resources/elastic_file_system.py
@@ -4,7 +4,6 @@
 
 
 import uuid
-import boto3
 import botocore
 import nixops.util
 import nixopsaws.ec2_utils

--- a/nixopsaws/resources/elastic_file_system_mount_target.py
+++ b/nixopsaws/resources/elastic_file_system_mount_target.py
@@ -3,12 +3,10 @@
 # AWS Elastic File System mount targets.
 
 
-import boto3
 import botocore
 import nixops.util
 import nixopsaws.ec2_utils
 import nixops.resources
-from . import ec2_common
 from . import efs_common
 from . import ec2_security_group
 from . import elastic_file_system

--- a/nixopsaws/resources/vpc.py
+++ b/nixopsaws/resources/vpc.py
@@ -2,15 +2,13 @@
 
 # Automatic provisioning of AWS VPCs.
 
-import boto3
 import botocore
 
 import nixops.util
 import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState
 import nixopsaws.ec2_utils
-from nixops.state import StateDict
-from nixops.diff import Diff, Handler
+from nixops.diff import Handler
 
 
 class VPCDefinition(nixops.resources.ResourceDefinition):

--- a/nixopsaws/resources/vpc_customer_gateway.py
+++ b/nixopsaws/resources/vpc_customer_gateway.py
@@ -3,15 +3,13 @@
 # Automatic provisioning of AWS VPC customer gateways.
 
 
-import boto3
 import botocore
 
 from nixops.state import StateDict
-from nixops.diff import Diff, Handler
+from nixops.diff import Handler
 import nixops.util
 import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState
-import nixopsaws.ec2_utils
 
 
 class VPCCustomerGatewayDefinition(nixops.resources.ResourceDefinition):

--- a/nixopsaws/resources/vpc_dhcp_options.py
+++ b/nixopsaws/resources/vpc_dhcp_options.py
@@ -3,7 +3,6 @@
 # Automatic provisioning of AWS VPC DHCP options.
 
 
-import boto3
 import botocore
 
 import nixops.util
@@ -11,7 +10,7 @@ import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState
 import nixopsaws.ec2_utils
 from nixops.state import StateDict
-from nixops.diff import Diff, Handler
+from nixops.diff import Handler
 
 
 class VPCDhcpOptionsDefinition(nixops.resources.ResourceDefinition):

--- a/nixopsaws/resources/vpc_egress_only_internet_gateway.py
+++ b/nixopsaws/resources/vpc_egress_only_internet_gateway.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import boto3
-import botocore
 
 from nixops.state import StateDict
-from nixops.diff import Diff, Handler
+from nixops.diff import Handler
 import nixops.util
 import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState

--- a/nixopsaws/resources/vpc_endpoint.py
+++ b/nixopsaws/resources/vpc_endpoint.py
@@ -3,7 +3,7 @@
 import uuid
 
 from nixops.state import StateDict
-from nixops.diff import Diff, Handler
+from nixops.diff import Handler
 import nixops.util
 import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState

--- a/nixopsaws/resources/vpc_internet_gateway.py
+++ b/nixopsaws/resources/vpc_internet_gateway.py
@@ -3,11 +3,8 @@
 # Automatic provisioning of AWS VPC internet gateways.
 
 
-import boto3
-import botocore
-
 from nixops.state import StateDict
-from nixops.diff import Diff, Handler
+from nixops.diff import Handler
 import nixops.util
 import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState

--- a/nixopsaws/resources/vpc_nat_gateway.py
+++ b/nixopsaws/resources/vpc_nat_gateway.py
@@ -5,14 +5,13 @@
 import uuid
 import time
 
-import boto3
 import botocore
 
 import nixops.util
 import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState
 import nixopsaws.ec2_utils
-from nixops.diff import Diff, Handler
+from nixops.diff import Handler
 from nixops.state import StateDict
 
 

--- a/nixopsaws/resources/vpc_network_acl.py
+++ b/nixopsaws/resources/vpc_network_acl.py
@@ -2,13 +2,12 @@
 
 # automatic provisioning of aws vpc network ACLs.
 
-import boto3
 import botocore
 import nixops.util
 import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState
 import nixopsaws.ec2_utils
-from nixops.diff import Diff, Handler
+from nixops.diff import Handler
 from nixops.state import StateDict
 
 

--- a/nixopsaws/resources/vpc_network_interface.py
+++ b/nixopsaws/resources/vpc_network_interface.py
@@ -2,14 +2,13 @@
 
 # Automatic provisioning of AWS VPC network interfaces.
 
-import boto3
 import botocore
 
 import nixops.util
 import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState
 import nixopsaws.ec2_utils
-from nixops.diff import Diff, Handler
+from nixops.diff import Handler
 from nixops.state import StateDict
 
 

--- a/nixopsaws/resources/vpc_network_interface_attachment.py
+++ b/nixopsaws/resources/vpc_network_interface_attachment.py
@@ -4,14 +4,13 @@
 
 import time
 
-import boto3
 import botocore
 
 import nixops.util
 import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState
 import nixopsaws.ec2_utils
-from nixops.diff import Diff, Handler
+from nixops.diff import Handler
 from nixops.state import StateDict
 
 

--- a/nixopsaws/resources/vpc_route.py
+++ b/nixopsaws/resources/vpc_route.py
@@ -2,14 +2,13 @@
 
 # Automatic provisioning of AWS VPC route.
 
-import boto3
 import botocore
 
 import nixops.util
 import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState
 import nixopsaws.ec2_utils
-from nixops.diff import Diff, Handler
+from nixops.diff import Handler
 from nixops.state import StateDict
 
 

--- a/nixopsaws/resources/vpc_route_table.py
+++ b/nixopsaws/resources/vpc_route_table.py
@@ -2,14 +2,13 @@
 
 # Automatic provisioning of AWS VPC route tables.
 
-import boto3
 import botocore
 
 import nixops.util
 import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState
 import nixopsaws.ec2_utils
-from nixops.diff import Diff, Handler
+from nixops.diff import Handler
 from nixops.state import StateDict
 
 

--- a/nixopsaws/resources/vpc_route_table_association.py
+++ b/nixopsaws/resources/vpc_route_table_association.py
@@ -2,14 +2,13 @@
 
 # Automatic provisioning of AWS VPC route table association.
 
-import boto3
 import botocore
 
 import nixops.util
 import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState
 import nixopsaws.ec2_utils
-from nixops.diff import Diff, Handler
+from nixops.diff import Handler
 from nixops.state import StateDict
 
 

--- a/nixopsaws/resources/vpc_subnet.py
+++ b/nixopsaws/resources/vpc_subnet.py
@@ -2,15 +2,13 @@
 
 # Automatic provisioning of AWS VPC subnets.
 
-import boto3
 import botocore
 
 import nixops.util
 import nixops.resources
 from nixopsaws.resources.ec2_common import EC2CommonState
 import nixopsaws.ec2_utils
-from nixops.diff import Diff, Handler
-from nixops.state import StateDict
+from nixops.diff import Handler
 
 
 class VPCSubnetDefinition(nixops.resources.ResourceDefinition):


### PR DESCRIPTION
Follow-up to #28, this removes non-stdlib imports with:

    autoflake --in-place --remove-all-unused-imports **/*.py

except for the API `__init__.py` file.

No manual or functional changes, just cleanup.