### PR TITLE
rds: accept configuring-enhanced-monitoring as a valid state

### DIFF
--- a/nixops_aws/resources/ec2_rds_dbinstance.py
+++ b/nixops_aws/resources/ec2_rds_dbinstance.py
@@ -225,6 +225,7 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState[EC2RDSDbInstanceDefin
                 "backing-up",
                 "available",
                 "modifying",
+                "configuring-enhanced-monitoring",
             }:
                 raise Exception(
                     "RDS database instance ‘{0}’ in an error state (state is ‘{1}’)".format(


### PR DESCRIPTION
Otherwise this may be considered a failed state during provisioning.