### PR TITLE
efs mount targets: allow passing a subnetid as Nix attrset

### DIFF
--- a/nixops_aws/nix/elastic-file-system-mount-target.nix
+++ b/nixops_aws/nix/elastic-file-system-mount-target.nix
@@ -24,7 +24,8 @@ with import ./lib.nix lib;
     };
 
     subnet = mkOption {
-      type = types.str;
+      type = types.either types.str (resource "vpc-subnet");
+      apply = x: if builtins.isString x then x else "res-" + x._name + "." + x._type;
       description = "The EC2 subnet in which to create this mount target.";
     };
 

--- a/nixops_aws/resources/elastic_file_system_mount_target.py
+++ b/nixops_aws/resources/elastic_file_system_mount_target.py
@@ -12,6 +12,7 @@ from . import ec2_security_group
 from . import elastic_file_system
 import time
 from .elastic_file_system import ElasticFileSystemState
+from .vpc_subnet import VPCSubnetState
 
 from .types.elastic_file_system_mount_target import ElasticFileSystemMountTargetOptions
 
@@ -118,6 +119,12 @@ class ElasticFileSystemMountTargetState(
                 args["IpAddress"] = defn.config["ipAddress"]
 
             subnetId = defn.config["subnet"]
+            if subnetId.startswith("res-"):
+                subnet_res = self.depl.get_typed_resource(
+                    subnetId[4:].split(".")[0], "vpc-subnet", VPCSubnetState
+                )
+                subnetId = subnet_res._state["subnetId"]
+
             securityGroups = self.security_groups_to_ids(
                 region, access_key_id, subnetId, defn.config["securityGroups"]
             )


### PR DESCRIPTION
While working on #108 I tested the EFS mount targets and figured this might be a desired change. A user can now finally pass a NixOps managed resource as subnet and doesn't have to hardcode the subnet's identifier as string.