### PR TITLE
RDS: Support VPC

### DIFF
--- a/nixops_aws/ec2_utils.py
+++ b/nixops_aws/ec2_utils.py
@@ -13,7 +13,10 @@ from boto.exception import BotoServerError
 from botocore.exceptions import ClientError
 from boto.pyami.config import Config
 import botocore
-from typing import Tuple
+from typing import Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import mypy_boto3_rds
 
 
 def fetch_aws_secret_key(access_key_id) -> Tuple[str, str]:
@@ -117,6 +120,18 @@ def connect_vpc(region, access_key_id):
     if not conn:
         raise Exception("invalid VPC region ‘{0}’".format(region))
     return conn
+
+
+def connect_rds_boto3(region, access_key_id) -> "mypy_boto3_rds.RDSClient":
+    assert region
+    (access_key_id, secret_access_key) = fetch_aws_secret_key(access_key_id)
+    client = boto3.session.Session().client(
+        "rds",
+        region_name=region,
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key=secret_access_key,
+    )
+    return client
 
 
 def get_access_key_id():

--- a/nixops_aws/ec2_utils.py
+++ b/nixops_aws/ec2_utils.py
@@ -164,7 +164,12 @@ def retry(f, error_codes=[], logger=None):
     def handle_boto3_exception(e):
         if i == num_retries:
             raise e
-        if logger is not None:
+        elif (
+            error_codes != []
+            and getattr(e, "response", {}).get("code") not in error_codes
+        ):
+            raise e
+        elif logger is not None:
             if hasattr(e, "response"):
                 logger.log(
                     "got (possibly transient) EC2 error '{}', retrying...".format(

--- a/nixops_aws/ec2_utils.py
+++ b/nixops_aws/ec2_utils.py
@@ -12,8 +12,7 @@ from boto.exception import SQSError
 from boto.exception import BotoServerError
 from botocore.exceptions import ClientError
 from boto.pyami.config import Config
-import botocore
-from typing import Tuple, TYPE_CHECKING
+from typing import Tuple, TYPE_CHECKING, Iterable, Any, Optional
 
 if TYPE_CHECKING:
     import mypy_boto3_rds
@@ -138,11 +137,16 @@ def get_access_key_id():
     return os.environ.get("EC2_ACCESS_KEY") or os.environ.get("AWS_ACCESS_KEY_ID")
 
 
-def retry(f, error_codes=[], logger=None):
+def retry(
+    f, error_codes: Optional[Iterable[Any]] = None, logger=None, num_retries: int = 7
+):
     """
         Retry function f up to 7 times. If error_codes argument is empty list, retry on all EC2 response errors,
         otherwise, only on the specified error codes.
     """
+
+    if error_codes is None:
+        error_codes = []
 
     def handle_exception(e):
         if hasattr(e, "error_code"):
@@ -152,8 +156,12 @@ def retry(f, error_codes=[], logger=None):
             err_code = e.response["Error"]["Code"]
             err_msg = e.response["Error"]["Message"]
 
-        if i == num_retries or (error_codes != [] and err_code not in error_codes):
-            raise e
+        if err_code == "RequestLimitExceeded":
+            return False
+
+        if error_codes and err_code not in error_codes:
+            return True
+
         if logger is not None:
             logger.log(
                 "got (possibly transient) EC2 error code '{0}': {1}. retrying...".format(
@@ -162,14 +170,10 @@ def retry(f, error_codes=[], logger=None):
             )
 
     def handle_boto3_exception(e):
-        if i == num_retries:
-            raise e
-        elif (
-            error_codes != []
-            and getattr(e, "response", {}).get("code") not in error_codes
-        ):
-            raise e
-        elif logger is not None:
+        if error_codes and getattr(e, "response", {}).get("code") not in error_codes:
+            return True
+
+        if logger is not None:
             if hasattr(e, "response"):
                 logger.log(
                     "got (possibly transient) EC2 error '{}', retrying...".format(
@@ -177,29 +181,23 @@ def retry(f, error_codes=[], logger=None):
                     )
                 )
 
+    def should_abort(e):
+        if isinstance(e, (SQSError, EC2ResponseError, BotoServerError)):
+            return handle_exception(e)
+        elif isinstance(e, ClientError):
+            return handle_boto3_exception(e)
+
     i = 0
-    num_retries = 7
     while i <= num_retries:
         i += 1
         next_sleep = 5 + random.random() * (2 ** i)
 
         try:
             return f()
-        except EC2ResponseError as e:
-            handle_exception(e)
-        except SQSError as e:
-            handle_exception(e)
-        except ClientError as e:
-            handle_boto3_exception(e)
-        except BotoServerError as e:
-            if e.error_code == "RequestLimitExceeded":
-                num_retries += 1
-            else:
-                handle_exception(e)
-        except botocore.exceptions.ClientError as e:
-            handle_exception(e)
         except Exception as e:
-            raise e
+            if num_retries == i or should_abort(e):
+                raise e
+            num_retries += 1
 
         time.sleep(next_sleep)
 

--- a/nixops_aws/nix/cloudwatch-log-group.nix
+++ b/nixops_aws/nix/cloudwatch-log-group.nix
@@ -14,6 +14,7 @@ with lib;
 
     accessKeyId = mkOption {
       type = types.str;
+      default = "";
       description = "The AWS Access Key ID.";
     };
 

--- a/nixops_aws/nix/cloudwatch-log-stream.nix
+++ b/nixops_aws/nix/cloudwatch-log-stream.nix
@@ -14,6 +14,7 @@ with lib;
 
     accessKeyId = mkOption {
       type = types.str;
+      default = "";
       description = "The AWS Access Key ID.";
     };
 

--- a/nixops_aws/nix/default.nix
+++ b/nixops_aws/nix/default.nix
@@ -18,6 +18,7 @@
     ebsVolumes = evalResources ./ebs-volume.nix (zipAttrs resourcesByType.ebsVolumes or []);
     elasticIPs = evalResources ./elastic-ip.nix (zipAttrs resourcesByType.elasticIPs or []);
     rdsDbInstances = evalResources ./ec2-rds-dbinstance.nix (zipAttrs resourcesByType.rdsDbInstances or []);
+    rdsSubnetGroups = evalResources ./rds-subnet-group.nix (zipAttrs resourcesByType.rdsSubnetGroups or []);
     rdsDbSecurityGroups = evalResources ./ec2-rds-dbsecurity-group.nix (zipAttrs resourcesByType.rdsDbSecurityGroups or []);
     route53RecordSets = evalResources ./route53-recordset.nix (zipAttrs resourcesByType.route53RecordSets or []);
     elasticFileSystems = evalResources ./elastic-file-system.nix (zipAttrs resourcesByType.elasticFileSystems or []);

--- a/nixops_aws/nix/ec2-rds-dbinstance.nix
+++ b/nixops_aws/nix/ec2-rds-dbinstance.nix
@@ -90,6 +90,15 @@ with import ./lib.nix lib;
       '';
     };
 
+    vpcSecurityGroups = mkOption {
+      default = [];
+      type = types.listOf (types.either types.str (resource "ec2-security-group"));
+      apply = map (x: if builtins.isString x then x else "res-" + x._name);
+      description = ''
+        List of VPC security groups to authorize on this DBInstance.
+      '';
+    };
+
   };
 
   config._type = "ec2-rds-dbinstance";

--- a/nixops_aws/nix/ec2-rds-dbinstance.nix
+++ b/nixops_aws/nix/ec2-rds-dbinstance.nix
@@ -81,6 +81,15 @@ with import ./lib.nix lib;
       description = "The endpoint address of the database instance.  This is set by NixOps.";
     };
 
+    subnetGroup = mkOption {
+      default = null;
+      type = types.nullOr (types.either types.str (resource "rds-subnet-group"));
+      apply = x: if builtins.isNull x then null else if builtins.isString x then x else "res-" + x._name;
+      description = ''
+        RDS Subnet Group to place this database in.
+      '';
+    };
+
     securityGroups = mkOption {
       default = [ "default" ];
       type = types.listOf (types.either types.str (resource "ec2-rds-security-group"));
@@ -91,8 +100,8 @@ with import ./lib.nix lib;
     };
 
     vpcSecurityGroups = mkOption {
-      default = [];
-      type = types.listOf (types.either types.str (resource "ec2-security-group"));
+      default = null;
+      type = types.nullOr (types.listOf (types.either types.str (resource "ec2-security-group")));
       apply = map (x: if builtins.isString x then x else "res-" + x._name);
       description = ''
         List of VPC security groups to authorize on this DBInstance.

--- a/nixops_aws/nix/elastic-file-system-mount-target.nix
+++ b/nixops_aws/nix/elastic-file-system-mount-target.nix
@@ -14,6 +14,7 @@ with import ./lib.nix lib;
 
     accessKeyId = mkOption {
       type = types.str;
+      default = "";
       description = "The AWS Access Key ID.";
     };
 

--- a/nixops_aws/nix/elastic-file-system.nix
+++ b/nixops_aws/nix/elastic-file-system.nix
@@ -13,6 +13,7 @@ with lib;
 
     accessKeyId = mkOption {
       type = types.str;
+      default = "";
       description = "The AWS Access Key ID.";
     };
 

--- a/nixops_aws/nix/iam-role.nix
+++ b/nixops_aws/nix/iam-role.nix
@@ -14,6 +14,7 @@ with lib;
 
     accessKeyId = mkOption {
       type = types.str;
+      default = "";
       description = "The AWS Access Key ID.";
     };
 

--- a/nixops_aws/nix/rds-subnet-group.nix
+++ b/nixops_aws/nix/rds-subnet-group.nix
@@ -1,0 +1,49 @@
+{ config, lib, uuid, name, ... }:
+
+with import ./lib.nix lib;
+with lib;
+with import ./lib.nix lib;
+
+{
+
+  options = {
+
+    name = mkOption {
+      default = "nixops-${uuid}-${name}";
+      type = types.str;
+      description = "Name of the RDS subnet group.";
+    };
+
+    description = mkOption {
+      default = "NixOps-provisioned subnet group ${name}";
+      type = types.str;
+      description = "Informational description of the subnet group.";
+    };
+
+    accessKeyId = mkOption {
+      default = "";
+      type = types.str;
+      description = "The AWS Access Key ID.";
+    };
+
+    region = mkOption {
+      example = "us-east-1";
+      type = types.str;
+      description = ''
+        AWS region in which the instance is to be deployed.
+      '';
+    };
+
+    subnetIds = mkOption {
+      default = [];
+      example = [ "subnet-00000000" ];
+      type = types.listOf (types.either types.str (resource "vpc-subnet"));
+      apply = map (x: if builtins.isString x then x else "res-" + x._name + "." + x._type);
+      description = ''
+        The subnets inside a VPC to launch the databases in.
+      '';
+    };
+  };
+
+  config._type = "rds-subnet-group";
+}

--- a/nixops_aws/nix/s3-bucket.nix
+++ b/nixops_aws/nix/s3-bucket.nix
@@ -19,6 +19,7 @@ with lib;
 
     accessKeyId = mkOption {
       type = types.str;
+      default = "";
       description = "The AWS Access Key ID.";
     };
 

--- a/nixops_aws/nix/sns-topic.nix
+++ b/nixops_aws/nix/sns-topic.nix
@@ -19,6 +19,7 @@ with lib;
 
     accessKeyId = mkOption {
       type = types.str;
+      default = "";
       description = "The AWS Access Key ID.";
     };
 

--- a/nixops_aws/nix/sqs-queue.nix
+++ b/nixops_aws/nix/sqs-queue.nix
@@ -19,6 +19,7 @@ with lib;
 
     accessKeyId = mkOption {
       type = types.str;
+      default = "";
       description = "The AWS Access Key ID.";
     };
 

--- a/nixops_aws/resources/ec2_rds_dbinstance.py
+++ b/nixops_aws/resources/ec2_rds_dbinstance.py
@@ -11,14 +11,25 @@ from uuid import uuid4
 from . import ec2_rds_dbsecurity_group
 from .ec2_rds_dbsecurity_group import EC2RDSDbSecurityGroupState
 from .ec2_security_group import EC2SecurityGroupState
+from .rds_db_subnet_group import RDSDbSubnetGroupState
 from .types.ec2_rds_dbinstance import Ec2RdsDbinstanceOptions
-from typing import Optional
+from typing import Optional, Sequence
+from typing_extensions import TypedDict
+
+
+class VpcOptions(TypedDict):
+    db_subnet_group_name: Optional[str]
+    security_groups: Optional[Sequence[str]]
+    vpc_security_groups: Optional[Sequence[str]]
 
 
 class EC2RDSDbInstanceDefinition(nixops.resources.ResourceDefinition):
     """Definition of an EC2 RDS Database Instance."""
 
     config: Ec2RdsDbinstanceOptions
+    subnet_group: Optional[str]
+    vpc_security_groups: Optional[Sequence[str]] = None
+    rds_dbinstance_security_groups: Optional[Sequence[str]] = None
 
     @classmethod
     def get_type(cls):
@@ -41,6 +52,27 @@ class EC2RDSDbInstanceDefinition(nixops.resources.ResourceDefinition):
         self.rds_dbinstance_engine: str = self.config.engine
         self.rds_dbinstance_db_name: str = self.config.dbName
         self.rds_dbinstance_multi_az: bool = self.config.multiAZ
+        self.subnet_group: Optional[str] = self.config.subnetGroup
+
+        if self.subnet_group is not None:
+            if self.config.vpcSecurityGroups is None:
+                raise Exception(
+                    f"rdsDbInstances.{name}.vpcSecurityGroups is required when subnetGroup is specified"
+                )
+            elif tuple(self.config.securityGroups) != ("default",):
+                raise Exception(
+                    f"rdsDbInstances.{name}.securityGroups is invalid when subnetGroup is specified"
+                )
+            else:
+                self.vpc_security_groups = self.config.vpcSecurityGroups
+        else:
+            if self.config.vpcSecurityGroups is not None:
+                raise Exception(
+                    f"rdsDbInstances.{name}.vpcSecurityGroups is invalid when subnetGroup is not specified"
+                )
+            else:
+                self.rds_dbinstance_security_groups = self.config.securityGroups
+
         # TODO: implement remainder of boto.rds.RDSConnection.create_dbinstance parameters
 
         # common params
@@ -77,6 +109,7 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState[EC2RDSDbInstanceDefin
     rds_dbinstance_db_name = nixops.util.attr_property("ec2.rdsDbName", None)
     rds_dbinstance_endpoint = nixops.util.attr_property("ec2.rdsEndpoint", None)
     rds_dbinstance_multi_az = nixops.util.attr_property("ec2.multiAZ", False)
+    subnet_group = nixops.util.attr_property("subnetGroup", None)
     rds_dbinstance_security_groups = nixops.util.attr_property(
         "ec2.securityGroups", [], "json"
     )
@@ -117,7 +150,8 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState[EC2RDSDbInstanceDefin
         return {
             r
             for r in resources
-            if isinstance(r, ec2_rds_dbsecurity_group.EC2RDSDbSecurityGroupState,)
+            if isinstance(r, ec2_rds_dbsecurity_group.EC2RDSDbSecurityGroupState)
+            or isinstance(r, RDSDbSubnetGroupState)
             or isinstance(
                 r, nixops_aws.resources.ec2_security_group.EC2SecurityGroupState
             )
@@ -255,6 +289,9 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState[EC2RDSDbInstanceDefin
             self.rds_dbinstance_master_username = dbinstance.master_username
             self.rds_dbinstance_engine = dbinstance.engine
             self.rds_dbinstance_multi_az = dbinstance.multi_az
+            if dbinstance.subnet_group:
+                self.subnet_group = dbinstance.subnet_group.name
+
             self.rds_dbinstance_port = int(dbinstance.endpoint[1])
             self.rds_dbinstance_endpoint = "%s:%d" % dbinstance.endpoint
             self.rds_dbinstance_security_groups = rds_security_groups
@@ -269,13 +306,31 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState[EC2RDSDbInstanceDefin
             "rds_dbinstance_security_groups": "security_groups",
             "vpc_security_groups": "vpc_security_groups",
         }
-        return {attr_to_kwarg[attr]: attrs[attr] for attr in attrs.keys()}
+        result = {attr_to_kwarg[attr]: attrs[attr] for attr in attrs.keys()}
+
+        # If the user has specified VPC security groups, and
+        # have left security groups as the default list of "default",
+        # they probably don't use the default security group --
+        # and it is incompatible with VPC security groups anyway.
+        if (
+            "vpc_security_groups" in result
+            and "security_groups" in result
+            and len(result["vpc_security_groups"]) > 0
+            and tuple(result["security_groups"]) == ("default",)
+        ):
+            del result["security_groups"]
+
+        return result
 
     def _compare_instance_id(self, instance_id):
         # take care when comparing instance ids, as aws lowercases and converts to unicode
         return str(self.rds_dbinstance_id).lower() == str(instance_id).lower()
 
-    def fetch_rds_security_group_resources(self, config):
+    def fetch_rds_security_group_resources(
+        self, config: Optional[Sequence[str]]
+    ) -> Optional[Sequence[str]]:
+        if config is None:
+            return None
         security_groups = []
         for sg in config:
             if sg.startswith("res-"):
@@ -289,14 +344,18 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState[EC2RDSDbInstanceDefin
                 security_groups.append(sg)
         return security_groups
 
-    def fetch_vpc_security_group_resources(self, config):
+    def fetch_vpc_security_group_resources(
+        self, config: Optional[Sequence[str]]
+    ) -> Optional[Sequence[str]]:
+        if config is None:
+            return None
         security_groups = []
         for sg in config:
             if sg.startswith("res-"):
                 res: EC2SecurityGroupState = self.depl.get_typed_resource(
                     sg[4:].split(".")[0], "ec2-security-group", EC2SecurityGroupState,
                 )
-                security_groups.append(res.security_group_name)
+                security_groups.append(res.security_group_id)
             else:
                 security_groups.append(sg)
         return security_groups
@@ -377,13 +436,8 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState[EC2RDSDbInstanceDefin
                             defn.rds_dbinstance_id
                         )
                     )
+
                     # create a new dbinstance with desired config
-                    security_groups = self.fetch_rds_security_group_resources(
-                        defn.rds_dbinstance_security_groups
-                    )
-                    vpc_security_groups = self.fetch_vpc_security_group_resources(
-                        defn.vpc_security_groups
-                    )
                     dbinstance = self._connect().create_dbinstance(
                         defn.rds_dbinstance_id,
                         defn.rds_dbinstance_allocated_storage,

--- a/nixops_aws/resources/ec2_rds_dbinstance.py
+++ b/nixops_aws/resources/ec2_rds_dbinstance.py
@@ -204,7 +204,7 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState[EC2RDSDbInstanceDefin
 
         def get_defn_attr(attr):
             if attr == "rds_dbinstance_security_groups":
-                return self.fetch_security_group_resources(
+                return self.fetch_rds_security_group_resources(
                     defn.rds_dbinstance_security_groups
                 )
             else:
@@ -267,7 +267,7 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState[EC2RDSDbInstanceDefin
         # take care when comparing instance ids, as aws lowercases and converts to unicode
         return str(self.rds_dbinstance_id).lower() == str(instance_id).lower()
 
-    def fetch_security_group_resources(self, config):
+    def fetch_rds_security_group_resources(self, config):
         security_groups = []
         for sg in config:
             if sg.startswith("res-"):
@@ -356,7 +356,7 @@ class EC2RDSDbInstanceState(nixops.resources.ResourceState[EC2RDSDbInstanceDefin
                         )
                     )
                     # create a new dbinstance with desired config
-                    security_groups = self.fetch_security_group_resources(
+                    security_groups = self.fetch_rds_security_group_resources(
                         defn.rds_dbinstance_security_groups
                     )
                     dbinstance = self._connect().create_dbinstance(

--- a/nixops_aws/resources/rds_db_subnet_group.py
+++ b/nixops_aws/resources/rds_db_subnet_group.py
@@ -1,0 +1,128 @@
+# -*- coding: utf-8 -*-
+
+# Automatic provisioning of EC2 security groups.
+
+import nixops.resources
+import nixops.util
+import nixops_aws.ec2_utils
+from typing import Optional, List, TYPE_CHECKING
+from .types.rds_db_subnet_group import RDSDbSubnetGroupOptions
+from .vpc_subnet import VPCSubnetState
+
+if TYPE_CHECKING:
+    import mypy_boto3_rds
+
+
+class RDSDbSubnetGroupDefinition(nixops.resources.ResourceDefinition):
+    """Definition of an RDS DB Subnet Group."""
+
+    config: RDSDbSubnetGroupOptions
+
+    @classmethod
+    def get_type(cls):
+        return "rds-subnet-group"
+
+    @classmethod
+    def get_resource_type(cls):
+        return "rdsSubnetGroups"
+
+
+class RDSDbSubnetGroupState(nixops.resources.ResourceState[RDSDbSubnetGroupDefinition]):
+    """State of an EC2 security group."""
+
+    definition_type = RDSDbSubnetGroupDefinition
+    group_name = nixops.util.attr_property("group_name", None)
+    region = nixops.util.attr_property("region", None)
+    description = nixops.util.attr_property("description", None)
+    subnet_ids = nixops.util.attr_property("subnet_ids", [], "json")
+
+    access_key_id: Optional[str] = None
+    _rds_conn: Optional["mypy_boto3_rds.RDSClient"] = None
+
+    @classmethod
+    def get_type(cls):
+        return "rds-subnet-group"
+
+    @property
+    def resource_id(self):
+        return self.group_name
+
+    def create_after(self, resources, defn):
+        return {r for r in resources if isinstance(r, VPCSubnetState)}
+
+    def _connect_rds(self) -> "mypy_boto3_rds.RDSClient":
+        if self._rds_conn:
+            return self._rds_conn
+        self._conn = nixops_aws.ec2_utils.connect_rds_boto3(
+            self.region, self.access_key_id
+        )
+        return self._conn
+
+    def create(
+        self,
+        defn: RDSDbSubnetGroupDefinition,
+        check: bool,
+        allow_reboot: bool,
+        allow_recreate: bool,
+    ):
+        self.region = defn.config.region
+        self.access_key_id = (
+            defn.config.accessKeyId or nixops_aws.ec2_utils.get_access_key_id()
+        )
+
+        if not self.access_key_id:
+            raise Exception(
+                "please set ‘accessKeyId’, $EC2_ACCESS_KEY or $AWS_ACCESS_KEY_ID"
+            )
+
+        if self.state == self.UP and (self.region != defn.config.region):
+            raise Exception(
+                "changing the region of an RDS Subnet Group is not supported"
+            )
+        if self.state == self.UP and (self.group_name != defn.config.name):
+            raise Exception("changing the name of an RDS Subnet Group is not supported")
+
+        self.group_name = defn.config.name
+        self.description = defn.config.description
+
+        subnets: List[str] = []
+        for s in defn.config.subnetIds:
+            if s.startswith("res-"):
+                res = self.depl.get_typed_resource(
+                    s[4:].split(".")[0], "vpc-subnet", VPCSubnetState
+                )
+                subnets.append(res._state["subnetId"])
+            else:
+                subnets.append(s)
+
+        if self.state != self.UP:
+            self.logger.log(f"Creating RDS Subnet Group {self.group_name}")
+            self._connect_rds().create_db_subnet_group(
+                DBSubnetGroupName=self.group_name,
+                DBSubnetGroupDescription=self.description,
+                SubnetIds=subnets,
+            )
+            self.state = self.UP
+        else:
+            self._connect_rds().modify_db_subnet_group(
+                DBSubnetGroupName=self.group_name,
+                DBSubnetGroupDescription=self.description,
+                SubnetIds=subnets,
+            )
+
+    def destroy(self, wipe=False):
+
+        self.access_key_id = nixops_aws.ec2_utils.get_access_key_id()
+        client = self._connect_rds()
+        try:
+            nixops_aws.ec2_utils.retry(
+                lambda: client.delete_db_subnet_group(
+                    DBSubnetGroupName=self.group_name
+                ),
+                error_codes=["DependencyViolation"],
+                logger=self.logger,
+            )
+        except client.exceptions.DBSubnetGroupNotFoundFault:
+            pass
+        self.state = self.MISSING
+        return True

--- a/nixops_aws/resources/types/ec2_rds_dbinstance.py
+++ b/nixops_aws/resources/types/ec2_rds_dbinstance.py
@@ -16,3 +16,4 @@ class Ec2RdsDbinstanceOptions(ResourceOptions):
     port: int
     region: str
     securityGroups: Sequence[str]
+    vpcSecurityGroups: Sequence[str]

--- a/nixops_aws/resources/types/ec2_rds_dbinstance.py
+++ b/nixops_aws/resources/types/ec2_rds_dbinstance.py
@@ -1,5 +1,5 @@
 from nixops.resources import ResourceOptions
-from typing import Sequence
+from typing import Sequence, Optional
 
 
 class Ec2RdsDbinstanceOptions(ResourceOptions):
@@ -15,5 +15,6 @@ class Ec2RdsDbinstanceOptions(ResourceOptions):
     multiAZ: bool
     port: int
     region: str
+    subnetGroup: Optional[str]
     securityGroups: Sequence[str]
-    vpcSecurityGroups: Sequence[str]
+    vpcSecurityGroups: Optional[Sequence[str]]

--- a/nixops_aws/resources/types/rds_db_subnet_group.py
+++ b/nixops_aws/resources/types/rds_db_subnet_group.py
@@ -1,0 +1,10 @@
+from typing import Sequence
+from nixops.resources import ResourceOptions
+
+
+class RDSDbSubnetGroupOptions(ResourceOptions):
+    accessKeyId: str
+    description: str
+    name: str
+    region: str
+    subnetIds: Sequence[str]


### PR DESCRIPTION
Create resources for subnet groups to allow RDS instances to be spawned in a VPC. Closes #57, #13, #6. 

cc @RaitoBezarius -- I didn't think to look for your PR before I wrote this (sorry :() but also that one is pre-py3, etc.