### PR TITLE
volumes: treat non-aliased devices as equivalent to aliased ones

### DIFF
--- a/nixops_aws/backends/ec2.py
+++ b/nixops_aws/backends/ec2.py
@@ -1551,10 +1551,12 @@ class EC2State(MachineState[EC2Definition], EC2CommonState):
 
         # Detect if volumes were manually detached.  If so, reattach
         # them.
+        mapped_devices = self._get_instance().block_device_mapping.keys()
+
         for device_stored, v in self.block_device_mapping.items():
             if (
-                device_name_to_boto_expected(device_stored)
-                not in self._get_instance().block_device_mapping.keys()
+                device_name_to_boto_expected(device_stored) not in mapped_devices
+                and device_stored not in mapped_devices
                 and not v.get("needsAttach", False)
                 and v.get("volumeId", None)
             ):
@@ -2041,8 +2043,12 @@ class EC2State(MachineState[EC2Definition], EC2CommonState):
                     device_real
                 )  # boto expects only sd names
 
-                if device_that_boto_expects not in instance.block_device_mapping.keys() and v.get(
-                    "volumeId", None
+                mapped_devices = instance.block_device_mapping.keys()
+
+                if (
+                    device_that_boto_expects not in mapped_devices
+                    and device_real not in mapped_devices
+                    and v.get("volumeId", None)
                 ):
                     res.disks_ok = False
                     res.messages.append(


### PR DESCRIPTION
The AWS API provides us with some non-sensical device names that might
have nothing to do with reality. For some reason there is weird renaming
going on from the values that boto3 (the AWS API bindings) returns to us
to what we actually configure on the machine. Apparently nowadays some
volumes are not properly being mapped from AWS to NixOps. Amazon doesn't
appear to give much of a guarantee (or any) in terms of device names.
Accepting the "real" device name instead of the mapped device name gets
rid of issue #105. In an ideal world Amazon would be providing WWUIDs,
device paths or some other attribute that they can define with the block
device. Since that doesn't (seem to) exist we must live with this change
until someone comes up with a better solution.