### PR TITLE
Allow Route53 recordsets to point at EIPs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Nix
-        uses: cachix/install-nix-action@v8
+        uses: cachix/install-nix-action@v12
       - name: Build
         run: 'nix-build -I nixpkgs=channel:nixos-unstable --quiet release.nix -A nixops-aws.x86_64-linux --show-trace'
   # Run black v19.10b0 and ensure no diff, using a pinned channel to ensure the
@@ -25,24 +25,30 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Nix
-        uses: cachix/install-nix-action@v8
+        uses: cachix/install-nix-action@v12
       - name: Black
         run: 'nix-shell ./shell.nix --run "black --check ."'
+        env:
+          NIX_PATH: "nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz"
   flake8:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Nix
-        uses: cachix/install-nix-action@v8
+        uses: cachix/install-nix-action@v12
       - name: Flake8
         run: 'nix-shell ./shell.nix --run "flake8 nixops_aws"'
+        env:
+          NIX_PATH: "nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz"
   mypy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Nix
-        uses: cachix/install-nix-action@v8
+        uses: cachix/install-nix-action@v12
       - name: Mypy
         run: 'nix-shell ./shell.nix --run "mypy nixops_aws"'
+        env:
+          NIX_PATH: "nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixos-unstable.tar.gz"

--- a/nixops_aws/nix/route53-recordset.nix
+++ b/nixops_aws/nix/route53-recordset.nix
@@ -81,7 +81,11 @@ with (import ./lib.nix lib);
     };
 
     recordValues = mkOption {
-      type = types.listOf (types.either types.str (resource "machine"));
+      type = types.listOf (types.oneOf [
+        types.str
+        (resource "machine")
+        (resource "elastic-ip")
+      ]);
 
       apply = l: map (x: if (builtins.isString x) || ( x == null) then x else "res-" + x._name) l;
 


### PR DESCRIPTION
Allow the values in a route53 recordset to be ElasticIP resources, in
the same way that they are allowed to be machine resources, and resolve
the ip address of the ElasticIP when creating the recordset.

Fixes #117

----

#