### PR TITLE
Support using STS session tokens in addition to keys

### DIFF
--- a/tests/unit/test_ec2_utils.py
+++ b/tests/unit/test_ec2_utils.py
@@ -1,0 +1,18 @@
+import os
+import unittest
+
+from nixops.util import fetch_aws_secret_key
+
+
+class TestEc2Utils(unittest.TestCase):
+    def test_session_token(self):
+        session_token = "DUMMY_SESSION_TOKEN"
+        security_token = "DUMMY_SECURITY_TOKEN"
+        self.assertIsNone(fetch_aws_secret_key("DUMMY_ACCESS_KEY")[2])
+
+        os.environ["AWS_SECURITY_TOKEN"] = security_token
+        self.assertIsEqual(fetch_aws_secret_key("DUMMY_ACCESS_KEY")[2], security_token)
+
+        # SESSION_TOKEN should take priority if it's set
+        os.environ["AWS_SESSION_TOKEN"] = session_token
+        self.assertIsEqual(fetch_aws_secret_key("DUMMY_ACCES_KEY")[2], session_token)


### PR DESCRIPTION
Another method for authentication to AWS is using STS keys.  This is common when
using 2FA or when using an identity account that ties together other delegated
accounts in AWS.  Session tokens are supported by Boto, we just need to expose
them to our connection methods.

This PR adds support for authenticating with session tokens when using
environment variables for authentication.  It does that by modifying the return
of `fetch_aws_secret_key` to return a tri-tuple where the 3rd item of the tuple
is the contents of AWS_SECURITY_TOKEN or AWS_SESSION_TOKEN, if available in the
environment.

Previous versions of different AWS tooling has used AWS_SECURITY_TOKEN as the
default environment variable.  However, the current standard is
AWS_SESSION_TOKEN.  This PR will use either of them with a preference towards
the AWS_SESSION_TOKEN environment variable.

In the case that ~/.ec2-key-pairs or ~/.aws/credentials is being used for
authentication, we just return `None` for the session token.
