### PR TITLE
Fix type error in ec2.nix and overly strict typing in route53_recordset.nix

### DIFF
--- a/nixops_aws/nix/ec2.nix
+++ b/nixops_aws/nix/ec2.nix
@@ -528,7 +528,7 @@ in
       let
         type = config.deployment.ec2.instanceType or "unknown";
         mapping = import ./ec2-properties.nix;
-      in attrByPath [ type ] null mapping;
+      in attrByPath [ type ] {} mapping;
 
   };
 


### PR DESCRIPTION
- Fix a type error in `ec2.nix`

- Allow any machine to be used in a Route53 record set, not just EC2 machines
Currently, the nix option type allows any machine to be specified, but the python code expects an EC2 machine, resulting in a deadlock when an unexpected machine type is used.