### PR TITLE
Adds missing t3.small ec2 property back

### DIFF
--- a/nixops_aws/nix/ec2-properties.nix
+++ b/nixops_aws/nix/ec2-properties.nix
@@ -168,6 +168,7 @@
   "t3a.micro" = { cores = 2; memory = 1024; allowsEbsOptimized = true; supportsNVMe = false;};
   "t3.nano" = { cores = 2; memory = 512; allowsEbsOptimized = true; supportsNVMe = false;};
   "t3a.nano" = { cores = 2; memory = 512; allowsEbsOptimized = true; supportsNVMe = false;};
+  "t3.small" = { cores = 2; memory = 2048; allowsEbsOptimized = true; supportsNVMe = false;};
   "t3a.small" = { cores = 2; memory = 2048; allowsEbsOptimized = true; supportsNVMe = false;};
   "t3.xlarge" = { cores = 4; memory = 16384; allowsEbsOptimized = true; supportsNVMe = false;};
   "t3a.xlarge" = { cores = 4; memory = 16384; allowsEbsOptimized = true; supportsNVMe = false;};


### PR DESCRIPTION
* Adds the missing t3.small instance type back which was inadvertently deleted in 24e7139bb219eab82817c57f9230b6a49e1c056e