### PR TITLE
Only use private IP for machines in the same region

### DIFF
--- a/nixops_aws/backends/ec2.py
+++ b/nixops_aws/backends/ec2.py
@@ -336,8 +336,9 @@ class EC2State(MachineState[EC2Definition], EC2CommonState):
         return self.vm_id
 
     def address_to(self, m):
-        if isinstance(m, EC2State):  # FIXME: only if we're in the same region
-            return m.private_ipv4
+        if isinstance(m, EC2State):
+            if self.region == m.region:
+                return m.private_ipv4
         return super().address_to(m)
 
     def _connect(self):


### PR DESCRIPTION
This just puts the check back to how it was when the code was originally written, it is at least *more* correct than before.