### PR TITLE
Update IRC reference in README.md to Libera

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repo contains the NixOps AWS Plugin.
 * [Source code](https://github.com/NixOS/nixops)
 * [Issue Tracker](https://github.com/NixOS/nixops/issues)
 * [Mailing list / Google group](https://groups.google.com/forum/#!forum/nixops-users)
-* [IRC - #nixos on freenode.net](irc://irc.freenode.net/#nixos)
+* [IRC - #nixos on libera.chat](irc://irc.libera.chat/#nixos)
 
 ## Developing
 


### PR DESCRIPTION
Update the IRC reference in README.md to libera.chat (see: https://nixos.wiki/wiki/Get_In_Touch#IRC)