### PR TITLE
Remove deprecated mkFixStrictness call

### DIFF
--- a/nixops_aws/nix/ec2.nix
+++ b/nixops_aws/nix/ec2.nix
@@ -508,12 +508,12 @@ in
     # Workaround: the evaluation of blockDeviceMapping requires fileSystems to be defined.
     fileSystems = {};
 
-    deployment.ec2.blockDeviceMapping = mkFixStrictness (listToAttrs
+    deployment.ec2.blockDeviceMapping = listToAttrs
       (map (fs: nameValuePair (dmToDevice fs.device)
         { inherit (fs.ec2) disk size deleteOnTermination encrypt cipher keySize passphrase iops volumeType encryptionType;
           fsType = if fs.fsType != "auto" then fs.fsType else fs.ec2.fsType;
         })
-       (filter (fs: fs.ec2 != null) (attrValues config.fileSystems))));
+       (filter (fs: fs.ec2 != null) (attrValues config.fileSystems)));
 
     deployment.autoLuks =
       let


### PR DESCRIPTION
It has been defined as the identity function for a long time.

See https://github.com/NixOS/nixpkgs/pull/129993