### PR TITLE
Fix route53RecordSet error message

### DIFF
--- a/nixops_aws/resources/route53_recordset.py
+++ b/nixops_aws/resources/route53_recordset.py
@@ -215,7 +215,7 @@ class Route53RecordSetState(nixops.resources.ResourceState[Route53RecordSetDefin
         if not defn.domain_name.endswith(zone_name):
             raise Exception(
                 "The domain name '{0}' does not end in the zone name '{1}'. You have to specify the FQDN for the zone name.".format(
-                    defn.domain_name, self.zone_name
+                    defn.domain_name, zone_name
                 )
             )
 


### PR DESCRIPTION
For the first run, it was

    The domain name 'foo.bar' does not end in the zone name 'None'. You have to specify the FQDN for the zone name.

because the self.zone_name is only initialized at the end.
Now it prints the zone name correctly:

    The domain name 'foo.bar' does not end in the zone name 'bar.'. You have to specify the FQDN for the zone name.

`zone_name` is always defined. The git blame does not provide an explanation for the choice of `self.zone_name`, so it isn't unreasonable to assume a mistake.

