### PR TITLE
Don't set removed ec2.hvm option

### DIFF
--- a/nixops_aws/backends/ec2.py
+++ b/nixops_aws/backends/ec2.py
@@ -267,8 +267,7 @@ class EC2State(MachineState[EC2Definition], EC2CommonState):
                 RawValue("<nixpkgs/nixos/modules/virtualisation/amazon-image.nix>")
             ],
             ("deployment", "ec2", "blockDeviceMapping"): block_device_mapping,
-            ("deployment", "ec2", "instanceId"): self.vm_id,
-            ("ec2", "hvm"): self.virtualization_type == "hvm"
+            ("deployment", "ec2", "instanceId"): self.vm_id
             or self.virtualization_type is None,
         }
 


### PR DESCRIPTION
When using nixpkgs after commit https://github.com/NixOS/nixpkgs/commit/24e33a4d2e41, I get the error

```
building all machine configurations...
error:
       Failed assertions:
       - The option definition `ec2.hvm' in `/tmp/nixops-tmpgkc5bopf/physical.nix' no longer has any effect; please remove it.
       Only HVM instances are supported, so specifying it is no longer necessary.

```

This change allows me to update my ec2 instances. According to the referenced commit message, "Paravirtualized EC2 instances haven't been supported since 2017." I am not sure exactly what that means. Is the option is still required by some Nixops users?